### PR TITLE
Add example for dealing with arbitrary queries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ use trino_rust_client::{ClientBuilder, Row, Trino};
 #[tokio::main]
 async fn main() {
     let cli = ClientBuilder::new("user", "localhost")
-        .port(8443)
+        .port(8080)
         .catalog("catalog")
         .build()
         .unwrap();

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ async fn main() {
 }
 ```
 
-### Example dealing with fields not know at compile time
+### Example dealing with fields not known at compile time
 ```rust
 use trino_rust_client::{ClientBuilder, Row, Trino};
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,30 @@ async fn main() {
 }
 ```
 
+### Example dealing with fields not know at compile time
+```rust
+use trino_rust_client::{ClientBuilder, Row, Trino};
+
+#[tokio::main]
+async fn main() {
+    let cli = ClientBuilder::new("user", "localhost")
+        .port(8443)
+        .catalog("catalog")
+        .build()
+        .unwrap();
+
+    let sql = "select first_name, last_name from users";
+
+    let rows = cli.get_all::<Row>(sql.into()).await.unwrap().into_vec();
+
+    for row in rows {
+        let first_name = row.value().get(0).unwrap();
+        let last_name = row.value().get(1).unwrap();
+        println!("{} : {}", first_name, last_name);
+    }
+}
+```
+
 ## License
 
 MIT


### PR DESCRIPTION
Adding example for dealing with arbitrary queries where the fields are not known at compile time.

Closes: #19 