### PR TITLE
Ensure the finished - prepared - statement's results are parsed accordingly

### DIFF
--- a/tests/data/models/query_result_finished_prepare
+++ b/tests/data/models/query_result_finished_prepare
@@ -1,0 +1,32 @@
+{
+  "id": "20250921_003348_00009_chu96",
+  "infoUri": "http://localhost:18080/ui/query.html?20250921_003348_00009_chu96",
+  "columns": [],
+  "stats": {
+    "state": "FINISHED",
+    "queued": false,
+    "scheduled": false,
+    "nodes": 0,
+    "totalSplits": 0,
+    "queuedSplits": 0,
+    "runningSplits": 0,
+    "completedSplits": 0,
+    "planningTimeMillis": 0,
+    "analysisTimeMillis": 0,
+    "cpuTimeMillis": 0,
+    "wallTimeMillis": 0,
+    "queuedTimeMillis": 9,
+    "elapsedTimeMillis": 29,
+    "finishingTimeMillis": 9,
+    "physicalInputTimeMillis": 0,
+    "processedRows": 0,
+    "processedBytes": 0,
+    "physicalInputBytes": 0,
+    "physicalWrittenBytes": 0,
+    "internalNetworkInputBytes": 0,
+    "peakMemoryBytes": 0,
+    "spilledBytes": 0
+  },
+  "warnings": [],
+  "updateType": "PREPARE"
+}

--- a/tests/query_result.rs
+++ b/tests/query_result.rs
@@ -73,6 +73,20 @@ fn test_finished() {
 }
 
 #[test]
+fn test_finished_prepare() {
+    let s = read("query_result_finished_prepare");
+    let d = serde_json::from_str::<QueryResult<A>>(&s).unwrap();
+
+    assert!(d.next_uri.is_none());
+    assert!(d.data_set.is_some());
+    assert!(d.error.is_none());
+
+    let data_set = d.data_set.unwrap();
+    assert!(data_set.is_empty());
+    assert!(data_set.split().0.is_empty());
+}
+
+#[test]
 fn test_failed() {
     let s = read("query_result_failed");
     let d = serde_json::from_str::<QueryResult<A>>(&s).unwrap();


### PR DESCRIPTION
Turns out in this situation, the `columns` field is set and empty, `data` isn't set. This was resulting in a `invalid trino type`