### PR TITLE
Fix prepared statement header decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ tokio = {version = "1.16", features = ["full"]}
 # self dependencies
 trino-rust-client-macros = {version = "0.5.1", path = "trino-rust-client-macros"}
 url = "2.5.4"
-urlencoding = "2.1"
 uuid = {version = "1.17", features = ["serde", "v4"]}
 
 [dev-dependencies]

--- a/src/types/util.rs
+++ b/src/types/util.rs
@@ -25,29 +25,6 @@ where
     }
 }
 
-pub struct SerializePairIterator<K: Serialize, V: Serialize, I: Iterator<Item = (K, V)> + Clone> {
-    pub iter: I,
-    pub size: Option<usize>,
-}
-
-impl<K, V, I> Serialize for SerializePairIterator<K, V, I>
-where
-    K: Serialize,
-    V: Serialize,
-    I: Iterator<Item = (K, V)> + Clone,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut s = serializer.serialize_map(self.size)?;
-        for (k, v) in self.iter.clone() {
-            s.serialize_entry(&k, &v)?;
-        }
-        s.end()
-    }
-}
-
 pub struct SerializeVecMap<K: Serialize, V: Serialize> {
     pub iter: Vec<(K, V)>,
 }


### PR DESCRIPTION
The issue is that `decode_kv_from_header` was not decoding `+` into the space character. Just like the [Python implementation](https://github.com/trinodb/trino-python-client/blob/2108c38dea79518ffb74370177df2dc95f1e6d96/trino/client.py#L332), this PR uses `url::form_urlencoded` to ensure headers are encoded/decoded properly.

Here's a snippet to repro:
```rust
use trino_rust_client::{ClientBuilder, Row};

#[tokio::main]
async fn main() {
    let client_builder = ClientBuilder::new("admin", "localhost").port(8080);
    let client = client_builder.build().unwrap();
    let _ = client.get_all::<Row>("PREPARE statement1 FROM SHOW TABLES".to_string()).await.unwrap();
    let _ = client.get_all::<Row>("EXECUTE statement1".to_string()).await.unwrap();
}
```

Output:
```bash
$ cargo run
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s
     Running `target/debug/playground`

thread 'main' panicked at src/main.rs:13:75:
called `Result::unwrap()` on an `Err` value: HttpNotOk(400, "Error 400 Bad Request: Invalid X-Trino-Prepared-Statement header: line 1:5: mismatched input '+'. Expecting: 'CATALOGS', 'COLUMNS', 'CREATE', 'CURRENT', 'FUNCTIONS', 'GRANTS', 'ROLE', 'ROLES', 'SCHEMAS', 'SESSION', 'STATS', 'TABLES'")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```