### PR TITLE
return execute result with operation type and counts

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -44,6 +44,8 @@ pub struct ClientBuilder {
 #[derive(Debug)]
 pub struct ExecuteResult {
     pub output_uri: Option<String>,
+    pub update_type: Option<String>,
+    pub update_count: Option<u64>,
 }
 
 impl ClientBuilder {
@@ -442,7 +444,11 @@ impl Client {
             return Err(error.into());
         }
 
-        Ok(ExecuteResult { output_uri: None })
+        Ok(ExecuteResult {
+            output_uri: None,
+            update_type: result.update_type,
+            update_count: result.update_count,
+        })
     }
 
     async fn try_get_retry_result(&self, url: &str) -> Result<TrinoRetryResult> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,6 +67,8 @@ pub struct TrinoRetryResult {
     pub error: Option<TrinoError>,
     #[serde(rename = "updateType")]
     pub update_type: Option<String>,
+    #[serde(rename = "updateCount")]
+    pub update_count: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
In current implementation if you try to run `DELETE` or `INSERT` via `execute`, the method doesn't provide any information about number of affected rows.

Because we already have this information in JSON response, we need only to parse it, similar to `QueryResult`