### PR TITLE
feat(spooling): implement the Spooling protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,17 @@
 [dependencies]
 backon = "1.5.2"
+base64 = {version = "0.22", optional = true}
 bigdecimal = "0.4.8"
 chrono = "0.4.42"
 chrono-tz = "0.10.4"
 derive_more = {version = "2.0.1", features = ["full"]}
+flate2 = {version = "1.0", optional = true}
 futures = "0.3"
 http = "1.3"
 iterable = "0.6"
 lazy_static = "1.5"
 log = "0.4.28"
+lz4 = {version = "1.28", optional = true}
 paste = "1.0.15"
 regex = "1.12.2"
 # network dependencies
@@ -23,9 +26,6 @@ trino-rust-client-macros = {version = "0.6.0", path = "trino-rust-client-macros"
 url = "2.5.7"
 uuid = {version = "1.18.1", features = ["serde", "v4"]}
 zstd = {version = "0.13", optional = true}
-base64 = {version ="0.22", optional = true}
-lz4 = {version = "1.28", optional = true}
-flate2 = {version = "1.0", optional = true}
 
 [dev-dependencies]
 dotenv = "0.15"
@@ -33,10 +33,15 @@ maplit = "1.0"
 trybuild = "1.0.112"
 wiremock = "0.6.5"
 
+[[example]]
+name = "spooling"
+path = "examples/spooling.rs"
+required-features = ["spooling"]
+
 [features]
 Trino = []
-spooling = ["base64", "zstd", "lz4", "flate2"]
 default = []
+spooling = ["base64", "zstd", "lz4", "flate2"]
 
 [package]
 authors = ["nudibranches technologies <contact@nudibranches.tech"]
@@ -50,6 +55,11 @@ name = "trino-rust-client"
 readme = "README.md"
 repository = "https://github.com/nudibranches-tech/trino-rust-client"
 version = "0.8.0"
+
+[[test]]
+name = "spooling_protocol"
+path = "tests/spooling_protocol.rs"
+required-features = ["spooling"]
 
 [workspace]
 members = [".", "trino-rust-client-macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ tokio = {version = "1.16", features = ["full"]}
 trino-rust-client-macros = {version = "0.6.0", path = "trino-rust-client-macros"}
 url = "2.5.7"
 uuid = {version = "1.18.1", features = ["serde", "v4"]}
+zstd = {version = "0.13", optional = true}
+base64 = {version ="0.22", optional = true}
+lz4 = {version = "1.28", optional = true}
+flate2 = {version = "1.0", optional = true}
 
 [dev-dependencies]
 dotenv = "0.15"
@@ -31,6 +35,7 @@ wiremock = "0.6.5"
 
 [features]
 Trino = []
+spooling = ["base64", "zstd", "lz4", "flate2"]
 default = []
 
 [package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,31 +1,31 @@
 [dependencies]
-backon = "1.5.2"
-base64 = {version = "0.22", optional = true}
-bigdecimal = "0.4.8"
-chrono = "0.4.42"
-chrono-tz = "0.10.4"
-derive_more = {version = "2.0.1", features = ["full"]}
-flate2 = {version = "1.0", optional = true}
-futures = "0.3"
-http = "1.3"
-iterable = "0.6"
-lazy_static = "1.5"
-log = "0.4.28"
-lz4 = {version = "1.28", optional = true}
-paste = "1.0.15"
-regex = "1.12.2"
+backon = {workspace = true}
+base64 = {workspace = true, optional = true}
+bigdecimal = {workspace = true}
+chrono = {workspace = true}
+chrono-tz = {workspace = true}
+derive_more = {workspace = true}
+flate2 = {workspace = true, optional = true}
+futures = {workspace = true}
+http = {workspace = true}
+iterable = {workspace = true}
+lazy_static = {workspace = true}
+log = {workspace = true}
+lz4 = {workspace = true, optional = true}
+paste = {workspace = true}
+regex = {workspace = true}
 # network dependencies
-reqwest = {version = "0.12.24", default-features = false, features = ["rustls-tls", "json"]}
+reqwest = {workspace = true}
 # third party dependencies
-serde = {version = "1.0", features = ["derive"]}
-serde_json = "1.0.145"
-thiserror = "2.0.17"
-tokio = {version = "1.16", features = ["full"]}
+serde = {workspace = true}
+serde_json = {workspace = true}
+thiserror = {workspace = true}
+tokio = {workspace = true}
 # self dependencies
-trino-rust-client-macros = {version = "0.6.0", path = "trino-rust-client-macros"}
-url = "2.5.7"
-uuid = {version = "1.18.1", features = ["serde", "v4"]}
-zstd = {version = "0.13", optional = true}
+trino-rust-client-macros = {workspace = true}
+url = {workspace = true}
+uuid = {workspace = true}
+zstd = {workspace = true, optional = true}
 
 [dev-dependencies]
 dotenv = "0.15"
@@ -44,17 +44,17 @@ default = []
 spooling = ["base64", "zstd", "lz4", "flate2"]
 
 [package]
-authors = ["nudibranches technologies <contact@nudibranches.tech"]
+authors = {workspace = true}
 description = "A trino client library"
-documentation = "https://docs.rs/trino-rust-client"
-edition = "2021"
-homepage = "https://github.com/nudibranches-tech/trino-rust-client"
+documentation = {workspace = true}
+edition = {workspace = true}
+homepage = {workspace = true}
 keywords = ["trino"]
-license = "MIT"
+license = {workspace = true}
 name = "trino-rust-client"
 readme = "README.md"
-repository = "https://github.com/nudibranches-tech/trino-rust-client"
-version = "0.8.0"
+repository = {workspace = true}
+version = {workspace = true}
 
 [[test]]
 name = "spooling_protocol"
@@ -62,4 +62,40 @@ path = "tests/spooling_protocol.rs"
 required-features = ["spooling"]
 
 [workspace]
-members = [".", "trino-rust-client-macros"]
+members = [".", "trino-rust-client-macros", "integration_tests"]
+
+[workspace.dependencies]
+backon = "1.5.2"
+base64 = "0.22"
+bigdecimal = "0.4.8"
+chrono = "0.4.42"
+chrono-tz = "0.10.4"
+derive_more = {version = "2.0.1", features = ["full"]}
+flate2 = "1.0"
+futures = "0.3"
+http = "1.3"
+iterable = "0.6"
+lazy_static = "1.5"
+log = "0.4.28"
+lz4 = "1.28"
+paste = "1.0.15"
+regex = "1.12.2"
+reqwest = {version = "0.12.24", default-features = false, features = ["rustls-tls", "json"]}
+serde = {version = "1.0", features = ["derive"]}
+serde_json = "1.0.145"
+thiserror = "2.0.17"
+tokio = {version = "1.16", features = ["full"]}
+tracing-subscriber = {version = "0.3", default-features = false, features = ["fmt", "env-filter"]}
+trino-rust-client-macros = {version = "0.6.0", path = "trino-rust-client-macros"}
+url = "2.5.7"
+uuid = {version = "1.18.1", features = ["serde", "v4"]}
+zstd = "0.13"
+
+[workspace.package]
+authors = ["nudibranches technologies <contact@nudibranches.tech"]
+documentation = "https://docs.rs/trino-rust-client"
+edition = "2021"
+homepage = "https://github.com/nudibranches-tech/trino-rust-client"
+license = "MIT"
+repository = "https://github.com/nudibranches-tech/trino-rust-client"
+version = "0.8.0"

--- a/examples/derive.rs
+++ b/examples/derive.rs
@@ -1,9 +1,10 @@
 use std::env::var;
 
 use dotenv::dotenv;
+use serde::{Deserialize, Serialize};
 use trino_rust_client::{ClientBuilder, Trino};
 
-#[derive(Trino, Debug)]
+#[derive(Trino, Debug, Deserialize, Serialize)]
 struct Foo {
     a: i64,
     b: f64,

--- a/examples/spooling.rs
+++ b/examples/spooling.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+use trino_rust_client::{ClientBuilder, DataSet, Trino};
+
+#[derive(Trino, Debug, Deserialize, Serialize)]
+struct User {
+    id: i64,
+    name: String,
+    email: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = ClientBuilder::new("user", "localhost")
+        .port(8080)
+        .catalog("memory")
+        .schema("default")
+        .spooling_encoding("json+zstd")
+        .max_concurrent_segments(10)
+        .build()?;
+
+    let sql = "SELECT id, name, email FROM users LIMIT 1000";
+
+    println!("Executing query: {}", sql);
+    let dataset: DataSet<User> = client.get_all::<User>(sql.to_string()).await?;
+
+    println!("Retrieved {} rows", dataset.len());
+
+    for (i, user) in dataset.as_slice().iter().take(5).enumerate() {
+        println!(
+            "Row {}: id={}, name={}, email={}",
+            i + 1,
+            user.id,
+            user.name,
+            user.email
+        );
+    }
+
+    if dataset.len() > 5 {
+        println!("... and {} more rows", dataset.len() - 5);
+    }
+
+    Ok(())
+}

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -1,0 +1,17 @@
+[dependencies]
+futures = {workspace = true}
+log = {workspace = true}
+reqwest = {workspace = true}
+tokio = {workspace = true}
+tracing-subscriber = {workspace = true}
+trino-rust-client = {path = "..", features = ["spooling"]}
+uuid = {workspace = true}
+
+[package]
+authors = {workspace = true}
+edition = {workspace = true}
+homepage = {workspace = true}
+license = {workspace = true}
+name = "trino-integration-tests"
+repository = {workspace = true}
+version = {workspace = true}

--- a/integration_tests/src/docker.rs
+++ b/integration_tests/src/docker.rs
@@ -1,0 +1,158 @@
+use log::error;
+use log::info;
+use log::warn;
+use std::process::Command;
+use std::thread::sleep;
+use std::time::Duration;
+
+#[derive(Debug)]
+pub struct DockerCompose {
+    project_name: String,
+    docker_compose_dir: String,
+}
+
+/// A utility to manage docker compose.
+impl DockerCompose {
+    pub fn new(project_name: impl ToString, docker_compose_dir: impl ToString) -> Self {
+        Self {
+            project_name: project_name.to_string(),
+            docker_compose_dir: docker_compose_dir.to_string(),
+        }
+    }
+
+    pub fn project_name(&self) -> &str {
+        self.project_name.as_str()
+    }
+
+    /// Get the OS and architecture of the host.
+    // This is used to set the DOCKER_DEFAULT_PLATFORM environment variable for the docker compose commands.
+    fn get_os_arch() -> String {
+        let mut cmd = Command::new("docker");
+        cmd.arg("info")
+            .arg("--format")
+            .arg("{{.OSType}}/{{.Architecture}}");
+
+        let output = cmd.output().expect("Failed to execute docker info");
+        if output.status.success() {
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        } else {
+            // Below tries an alternative path if the above path fails
+            let mut alt_cmd = Command::new("docker");
+            alt_cmd
+                .arg("info")
+                .arg("--format")
+                .arg("{{.Version.OsArch}}");
+            let alt_output = alt_cmd.output().expect("Failed to execute docker info");
+            String::from_utf8_lossy(&alt_output.stdout)
+                .trim()
+                .to_string()
+        }
+    }
+
+    /// Start the docker compose services.
+    pub fn up(&self) {
+        let mut cmd = Command::new("docker");
+        cmd.current_dir(&self.docker_compose_dir);
+
+        cmd.env("DOCKER_DEFAULT_PLATFORM", Self::get_os_arch());
+
+        cmd.args(vec![
+            "compose",
+            "-p",
+            self.project_name.as_str(),
+            "up",
+            "-d",
+        ]);
+
+        info!(
+            "Starting docker compose in {}, project name: {}",
+            self.docker_compose_dir, self.project_name
+        );
+        let output = cmd.output().expect("Failed to execute docker compose up");
+
+        if !output.status.success() {
+            error!(
+                "Docker compose up failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+
+            panic!("Docker compose up failed!")
+        }
+
+        // Wait for the coordinator and worker to be healthy
+        self.wait_for_service_healthy("minio", 120);
+        self.wait_for_service_healthy("coordinator", 120);
+
+        // Wait a bit more to ensure Trino is ready to accept queries.
+        let extra_wait_time = 15;
+        info!(
+            "Waiting an extra {}s for Trino server initialization...",
+            extra_wait_time
+        );
+        sleep(Duration::from_secs(extra_wait_time));
+    }
+
+    /// Wait for a service to be healthy.
+    fn wait_for_service_healthy(&self, service_name: &str, timeout_seconds: u64) {
+        let container_name = format!("{}-{}-1", self.project_name, service_name);
+        let start = std::time::Instant::now();
+
+        info!(
+            "Waiting for {} to be healthy (timeout: {}s)",
+            container_name, timeout_seconds
+        );
+
+        loop {
+            let mut cmd = Command::new("docker");
+            cmd.arg("inspect")
+                .arg("--format")
+                .arg("{{.State.Health.Status}}")
+                .arg(&container_name);
+
+            if let Ok(output) = cmd.output() {
+                if output.status.success() {
+                    let health_status = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                    if health_status == "healthy" {
+                        info!("{} is healthy", container_name);
+                        return;
+                    }
+                }
+            }
+
+            if start.elapsed().as_secs() > timeout_seconds {
+                error!("Timeout waiting for {} to be healthy", container_name);
+                panic!("Timeout waiting for {} to be healthy", container_name);
+            }
+
+            sleep(Duration::from_secs(2));
+        }
+    }
+
+    /// Stop and remove all containers created by this docker compose.
+    pub fn down(&self) {
+        let mut cmd = Command::new("docker");
+        cmd.current_dir(&self.docker_compose_dir);
+
+        cmd.args(vec![
+            "compose",
+            "-p",
+            self.project_name.as_str(),
+            "down",
+            "-v",
+            "--remove-orphans",
+        ]);
+
+        info!(
+            "Stopping docker compose in {}, project name: {}",
+            self.docker_compose_dir, self.project_name
+        );
+        let output = cmd.output().expect("Failed to execute docker compose down");
+
+        if !output.status.success() {
+            warn!(
+                "Docker compose down had issues (this is usually fine): {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+}

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -1,0 +1,44 @@
+mod docker;
+
+use docker::DockerCompose;
+use std::sync::Once;
+
+pub struct TestFixture {
+    pub _docker_compose: DockerCompose,
+    pub coordinator_host: String,
+    pub coordinator_port: u16,
+}
+
+static INIT: Once = Once::new();
+
+// Set up the test fixture.
+pub fn set_up() -> DockerCompose {
+    let docker_compose = DockerCompose::new(
+        "trino_integration_tests",
+        format!("{}/test_setup", env!("CARGO_MANIFEST_DIR")),
+    );
+
+    // Ensure docker compose is started only once
+    INIT.call_once(|| {
+        // Clean up any existing containers from previous runs
+        docker_compose.down();
+        // Start the containers
+        docker_compose.up();
+    });
+
+    docker_compose
+}
+
+// Set up the test fixture.
+pub fn set_test_fixture(_func: &str) -> TestFixture {
+    let docker_compose = set_up();
+
+    let coordinator_port = 8080;
+    let coordinator_host = "localhost".to_string();
+
+    TestFixture {
+        _docker_compose: docker_compose,
+        coordinator_host,
+        coordinator_port,
+    }
+}

--- a/integration_tests/test_setup/docker-compose.yml
+++ b/integration_tests/test_setup/docker-compose.yml
@@ -1,0 +1,71 @@
+services:
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    ports:
+      - "9003:9003"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+      # Allow SSE-C over HTTP for local testing
+      MINIO_API_ALLOW_INSECURE_SSE_CUSTOMER_REQUEST: "on"
+    command: server /data --console-address ":9001" --address ":9003"
+    volumes:
+      - minio_data:/data
+    networks:
+      - trino-network
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/9003'"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  createbuckets:
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    restart: "no"
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set myminio http://minio:9003 minioadmin minioadmin;
+      mc mb myminio/spooling --ignore-existing;
+      mc anonymous set download myminio/spooling;
+      exit 0;
+      "
+    networks:
+      - trino-network
+
+  coordinator:
+    image: trinodb/trino:478
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./trino/etc/coordinator:/etc/trino
+    environment:
+      - JAVA_OPTS=-Xmx1G -XX:+UseG1GC -XX:G1HeapRegionSize=32M
+    depends_on:
+      - minio
+      - createbuckets
+    networks:
+      - trino-network
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+        reservations:
+          memory: 1G
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/v1/info"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+networks:
+  trino-network:
+    driver: bridge
+
+volumes:
+  minio_data:
+  trino_coordinator_data:

--- a/integration_tests/test_setup/trino/etc/coordinator/catalog/memory.properties
+++ b/integration_tests/test_setup/trino/etc/coordinator/catalog/memory.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/integration_tests/test_setup/trino/etc/coordinator/config.properties
+++ b/integration_tests/test_setup/trino/etc/coordinator/config.properties
@@ -1,0 +1,17 @@
+coordinator=true
+node-scheduler.include-coordinator=true
+http-server.http.port=8080
+discovery.uri=http://coordinator:8080
+
+# Spooling enabled for testing
+protocol.spooling.enabled=true
+protocol.spooling.shared-secret-key=2gRX9nSTMat9O9Mo3FmNQ5YKwWP78WRMBPrMNRtvP3M=
+
+# Force S3 spooling for smaller datasets (for testing)
+# Set to very low values to force spooling
+protocol.spooling.inlining.max-size=1kB
+protocol.spooling.inlining.max-rows=1
+
+# Lower segment size to force early spooling (default: 8MB initial, 16MB max)
+protocol.spooling.initial-segment-size=1kB
+protocol.spooling.max-segment-size=1kB

--- a/integration_tests/test_setup/trino/etc/coordinator/jvm.config
+++ b/integration_tests/test_setup/trino/etc/coordinator/jvm.config
@@ -1,0 +1,4 @@
+-server
+-Xmx1G
+-XX:+UseG1GC
+-XX:+ExitOnOutOfMemoryError

--- a/integration_tests/test_setup/trino/etc/coordinator/node.properties
+++ b/integration_tests/test_setup/trino/etc/coordinator/node.properties
@@ -1,0 +1,3 @@
+node.environment=testing
+node.id=ffffffff-ffff-ffff-ffff-ffffffffffff
+node.data-dir=/tmp/trino/data

--- a/integration_tests/test_setup/trino/etc/coordinator/spooling-manager.properties
+++ b/integration_tests/test_setup/trino/etc/coordinator/spooling-manager.properties
@@ -1,0 +1,10 @@
+spooling-manager.name=filesystem
+fs.s3.enabled=true
+fs.location=s3://spooling/segments
+s3.endpoint=http://minio:9003
+s3.region=us-east-1
+s3.aws-access-key=minioadmin
+s3.aws-secret-key=minioadmin
+s3.path-style-access=true
+# Disable encryption for local HTTP testing
+fs.segment.encryption=false

--- a/integration_tests/test_setup/trino/etc/worker/catalog/memory.properties
+++ b/integration_tests/test_setup/trino/etc/worker/catalog/memory.properties
@@ -1,0 +1,1 @@
+connector.name=memory

--- a/integration_tests/test_setup/trino/etc/worker/config.properties
+++ b/integration_tests/test_setup/trino/etc/worker/config.properties
@@ -1,0 +1,16 @@
+coordinator=false
+http-server.http.port=8080
+discovery.uri=http://coordinator:8080
+
+# Enable spooling protocol
+protocol.spooling.enabled=true
+protocol.spooling.shared-secret-key=qdI43qtiRZfi4p83I0PdUZuRbZkjsLm4catbQaDWW6M=
+
+# Force S3 spooling for smaller datasets (for testing)
+# Set to very low values to force spooling
+protocol.spooling.inlining.max-size=2kB
+protocol.spooling.inlining.max-rows=10
+
+# Lower segment size to force early spooling (default: 8MB initial, 16MB max)
+protocol.spooling.initial-segment-size=50kB
+protocol.spooling.max-segment-size=500kB

--- a/integration_tests/test_setup/trino/etc/worker/jvm.config
+++ b/integration_tests/test_setup/trino/etc/worker/jvm.config
@@ -1,0 +1,4 @@
+-server
+-Xmx1G
+-XX:+UseG1GC
+-XX:+ExitOnOutOfMemoryError

--- a/integration_tests/test_setup/trino/etc/worker/node.properties
+++ b/integration_tests/test_setup/trino/etc/worker/node.properties
@@ -1,0 +1,3 @@
+node.environment=testing
+node.id=ffffffff-ffff-ffff-ffff-fffffffffff0
+node.data-dir=/tmp/trino/data

--- a/integration_tests/test_setup/trino/etc/worker/spooling-manager.properties
+++ b/integration_tests/test_setup/trino/etc/worker/spooling-manager.properties
@@ -1,0 +1,10 @@
+spooling-manager.name=filesystem
+fs.s3.enabled=true
+fs.location=s3://spooling/segments
+s3.endpoint=http://minio:9003
+s3.region=us-east-1
+s3.aws-access-key=minioadmin
+s3.aws-secret-key=minioadmin
+s3.path-style-access=true
+# Disable encryption for local HTTP testing
+fs.segment.encryption=false

--- a/integration_tests/tests/spooling_test.rs
+++ b/integration_tests/tests/spooling_test.rs
@@ -1,0 +1,137 @@
+use futures::FutureExt;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use trino_integration_tests::{set_test_fixture, TestFixture};
+use trino_rust_client::spooling::SegmentFetcher;
+use trino_rust_client::{Client, ClientBuilder, Row, Trino};
+use uuid::Uuid;
+
+/// Helper to create a client that can resolve 'minio' hostname to localhost
+/// This is needed because Trino running in Docker returns 'http://minio:9000/...'
+/// but the test running on host needs to access it via localhost:9000.
+fn create_test_client(fixture: &TestFixture, encoding: &str) -> Client {
+    let docker_port = 9003;
+    let http_client = reqwest::Client::builder()
+        .resolve(
+            "minio",
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), docker_port),
+        )
+        .build()
+        .expect("Failed to create http client");
+
+    let fetcher = SegmentFetcher::new(http_client);
+    // Enable spooling protocol
+    ClientBuilder::new("test", &fixture.coordinator_host)
+        .port(fixture.coordinator_port)
+        .catalog("memory")
+        .schema("default")
+        .spooling_encoding(encoding)
+        .max_concurrent_segments(5)
+        .segment_fetcher(fetcher)
+        .build()
+        .expect("Failed to create client")
+}
+
+/// Helper to run a test with a temporary table that gets cleaned up automatically.
+async fn with_temp_table<F, Fut>(client: &Client, create_sql_template: &str, test_fn: F)
+where
+    F: FnOnce(String) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let table_name = format!("memory.default.table_{}", Uuid::new_v4().simple());
+    let create_sql = create_sql_template.replace("{}", &table_name);
+    client
+        .execute(create_sql)
+        .await
+        .expect("Failed to create temp table");
+
+    let result = std::panic::AssertUnwindSafe(test_fn(table_name.clone()))
+        .catch_unwind()
+        .await;
+
+    let drop_sql = format!("DROP TABLE IF EXISTS {}", table_name);
+    if let Err(e) = client.execute(drop_sql).await {
+        eprintln!("Failed to drop temp table {}: {:?}", table_name, e);
+    }
+
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
+}
+
+#[tokio::test]
+async fn test_spooling_protocol_encodings() {
+    let fixture = set_test_fixture("test_spooling_protocol_encodings");
+
+    // Client for setup (standard client is fine for setup)
+    let setup_client = ClientBuilder::new("test", &fixture.coordinator_host)
+        .port(fixture.coordinator_port)
+        .catalog("memory")
+        .schema("default")
+        .build()
+        .expect("Failed to create setup client");
+
+    // Create table with 100 rows (enough to trigger spooling limit of 10)
+    let create_sql_template = r#"
+        CREATE TABLE {} AS
+        SELECT 
+            CAST(n AS BIGINT) AS id,
+            CONCAT('user_', CAST(n AS VARCHAR)) AS name,
+            CAST(n * 10 AS BIGINT) AS value
+        FROM UNNEST(SEQUENCE(1, 100)) AS t(n)
+    "#;
+
+    with_temp_table(
+        &setup_client,
+        create_sql_template,
+        |table_name| async move {
+            let encodings = vec!["json", "json+zstd", "json+lz4"];
+
+            for encoding in encodings {
+                // Create client with custom DNS resolution and specific encoding
+                let client = create_test_client(&fixture, encoding);
+
+                let select_sql = format!("SELECT * FROM {} ORDER BY id", table_name);
+                let rows = client
+                    .get_all::<Row>(select_sql)
+                    .await
+                    .unwrap_or_else(|e| panic!("Query with {} encoding failed: {:?}", encoding, e));
+
+                assert_eq!(
+                    rows.len(),
+                    100,
+                    "{} encoding should return all 100 rows",
+                    encoding
+                );
+
+                let first = &rows.as_slice()[0];
+                assert_eq!(
+                    first.value().get(0).unwrap(),
+                    &1i64,
+                    "First ID mismatch ({})",
+                    encoding
+                );
+                assert_eq!(
+                    first.value().get(1).unwrap(),
+                    &"user_1".to_string(),
+                    "First Name mismatch ({})",
+                    encoding
+                );
+
+                let last = &rows.as_slice()[99];
+                assert_eq!(
+                    last.value().get(0).unwrap(),
+                    &100i64,
+                    "Last ID mismatch ({})",
+                    encoding
+                );
+                assert_eq!(
+                    last.value().get(1).unwrap(),
+                    &"user_100".to_string(),
+                    "Last Name mismatch ({})",
+                    encoding
+                );
+            }
+        },
+    )
+    .await;
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,7 +43,7 @@ pub enum Error {
     #[error("http not ok, code: {0}, reason: {1}")]
     HttpNotOk(StatusCode, String),
     #[error("query error, reason: {0}")]
-    QueryError(#[from] QueryError),
+    QueryError(Box<QueryError>),
     #[error("inconsistent data")]
     InconsistentData,
     #[error("empty data")]
@@ -54,6 +54,12 @@ pub enum Error {
     InvalidHost(String),
     #[error("internal error: {0}")]
     InternalError(String),
+}
+
+impl From<QueryError> for Error {
+    fn from(err: QueryError) -> Self {
+        Error::QueryError(Box::new(err))
+    }
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/header.rs
+++ b/src/header.rs
@@ -17,6 +17,7 @@ pub static HEADER_CLIENT_TAGS: &str = "X-Trino-Client-Tags";
 pub static HEADER_CLIENT_CAPABILITIES: &str = "X-Trino-Client-Capabilities";
 pub static HEADER_RESOURCE_ESTIMATE: &str = "X-Trino-Resource-Estimate";
 pub static HEADER_EXTRA_CREDENTIAL: &str = "X-Trino-Extra-Credential";
+#[cfg(feature = "spooling")]
 pub static HEADER_SPOOLING: &str = "X-Trino-Query-Data-Encoding";
 
 // response headers

--- a/src/header.rs
+++ b/src/header.rs
@@ -17,6 +17,7 @@ pub static HEADER_CLIENT_TAGS: &str = "X-Trino-Client-Tags";
 pub static HEADER_CLIENT_CAPABILITIES: &str = "X-Trino-Client-Capabilities";
 pub static HEADER_RESOURCE_ESTIMATE: &str = "X-Trino-Resource-Estimate";
 pub static HEADER_EXTRA_CREDENTIAL: &str = "X-Trino-Extra-Credential";
+pub static HEADER_SPOOLING: &str = "X-Trino-Query-Data-Encoding";
 
 // response headers
 pub static HEADER_SET_CATALOG: &str = "X-Trino-Set-Catalog";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ pub mod error;
 
 mod header;
 pub mod models;
+#[cfg(feature = "spooling")]
+pub mod spooling;
 
 pub mod selected_role;
 pub mod session;

--- a/src/models/result.rs
+++ b/src/models/result.rs
@@ -1,8 +1,100 @@
 use serde::Deserialize;
+use std::collections::HashMap;
 
 use super::*;
-use crate::{DataSet, Trino};
+#[cfg(feature = "spooling")]
+use crate::error::Error;
+#[cfg(feature = "spooling")]
+use crate::spooling::{decode_inline_segment, Segment};
+use crate::Trino;
 
+/// Query result data can be either Direct (inline array) or Spooled (compressed segments)
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+#[serde(untagged)]
+pub enum QueryResultData<T: Trino> {
+    // Spooled protocol: data is an object with encoding and segments
+    Spooled(SpooledData),
+    // Direct protocol: data is a simple JSON array
+    #[serde(bound(deserialize = "Vec<T>: Deserialize<'de>"))]
+    Direct(Vec<T>),
+}
+
+impl<T> QueryResultData<T>
+where
+    T: Trino,
+    for<'de> T: serde::Deserialize<'de>,
+{
+    /// Convert into Vec for both Direct and Spooled variants
+    pub fn into_vec(self) -> Vec<T> {
+        match self {
+            QueryResultData::Direct(data) => data,
+            #[cfg(feature = "spooling")]
+            QueryResultData::Spooled(spooled) => spooled.parse_segments().unwrap_or_else(|e| {
+                log::error!("Failed to parse spooled segments: {}", e);
+                Vec::new()
+            }),
+            #[cfg(not(feature = "spooling"))]
+            QueryResultData::Spooled(_) => {
+                panic!("Spooling feature not enabled")
+            }
+        }
+    }
+}
+
+/// Spooled data contains encoding format and segment references
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SpooledData {
+    pub encoding: String,
+    #[cfg(feature = "spooling")]
+    pub segments: Vec<Segment>,
+}
+
+#[cfg(feature = "spooling")]
+impl SpooledData {
+    /// Parse all segments and return the rows
+    fn parse_segments<T>(&self) -> Result<Vec<T>, Error>
+    where
+        for<'de> T: Trino + serde::Deserialize<'de>,
+    {
+        let mut all_rows = Vec::new();
+
+        for (idx, segment) in self.segments.iter().enumerate() {
+            match segment {
+                Segment::Inlined { data, .. } => {
+                    let decompressed = decode_inline_segment(data, &self.encoding)?;
+                    let rows: Vec<T> = serde_json::from_str(&decompressed).map_err(|e| {
+                        Error::InternalError(format!("Failed to parse segment {} JSON: {}", idx, e))
+                    })?;
+                    all_rows.reserve(rows.len());
+                    for row in rows {
+                        all_rows.push(row);
+                    }
+                }
+                Segment::Spooled { .. } => {
+                    return Err(Error::InternalError(
+                        "Remote spooled segments not supported in this code path. Use Client::get_all() instead.".to_string(),
+                    ));
+                }
+            }
+        }
+
+        Ok(all_rows)
+    }
+}
+
+/// Metadata about spooled data segments
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DataAttributes {
+    pub rows_count: Option<u64>,
+    pub segment_size: Option<u64>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Trino query result
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryResult<T: Trino> {
@@ -11,9 +103,11 @@ pub struct QueryResult<T: Trino> {
     pub partial_cancel_uri: Option<String>,
     pub next_uri: Option<String>,
 
-    #[serde(flatten)]
-    #[serde(bound(deserialize = "Option<DataSet<T>>: Deserialize<'de>"))]
-    pub data_set: Option<DataSet<T>>,
+    pub columns: Option<Vec<Column>>,
+
+    #[serde(bound(deserialize = "Option<QueryResultData<T>>: Deserialize<'de>"))]
+    pub data: Option<QueryResultData<T>>,
+
     pub error: Option<QueryError>,
 
     pub stats: Stat,
@@ -21,4 +115,55 @@ pub struct QueryResult<T: Trino> {
 
     pub update_type: Option<String>,
     pub update_count: Option<u64>,
+}
+
+#[cfg(test)]
+#[cfg(feature = "spooling")]
+mod tests {
+    use super::*;
+    use base64::prelude::*;
+
+    #[test]
+    fn test_parse_segments_multiple_inline() {
+        let rows_json1 = r#"[["alice",1],["bob",2]]"#;
+        let rows_json2 = r#"[["charlie",3]]"#;
+
+        let encoded1 = BASE64_STANDARD.encode(rows_json1.as_bytes());
+        let encoded2 = BASE64_STANDARD.encode(rows_json2.as_bytes());
+
+        let segment1_json = format!(
+            r#"{{"type":"inline","data":"{}","metadata":{{}}}}"#,
+            encoded1
+        );
+        let segment2_json = format!(
+            r#"{{"type":"inline","data":"{}","metadata":{{}}}}"#,
+            encoded2
+        );
+
+        let segment1: Segment = serde_json::from_str(&segment1_json).unwrap();
+        let segment2: Segment = serde_json::from_str(&segment2_json).unwrap();
+
+        let spooled = SpooledData {
+            encoding: "json".to_string(),
+            segments: vec![segment1, segment2],
+        };
+
+        let rows = spooled.parse_segments::<crate::Row>().unwrap();
+        assert_eq!(rows.len(), 3);
+        assert_eq!(
+            rows[0].value()[0],
+            serde_json::Value::String("alice".to_string())
+        );
+        assert_eq!(rows[0].value()[1], serde_json::Value::Number(1.into()));
+        assert_eq!(
+            rows[1].value()[0],
+            serde_json::Value::String("bob".to_string())
+        );
+        assert_eq!(rows[1].value()[1], serde_json::Value::Number(2.into()));
+        assert_eq!(
+            rows[2].value()[0],
+            serde_json::Value::String("charlie".to_string())
+        );
+        assert_eq!(rows[2].value()[1], serde_json::Value::Number(3.into()));
+    }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -36,6 +36,7 @@ pub struct Session {
     pub transaction_id: TransactionId,
     pub client_request_timeout: Duration,
     pub compression_disabled: bool,
+    pub spooling_encoding: Option<String>,
 }
 
 #[derive(Debug)]
@@ -61,6 +62,7 @@ pub(crate) struct SessionBuilder {
     pub(crate) transaction_id: TransactionId,
     pub(crate) client_request_timeout: Duration,
     pub(crate) compression_disabled: bool,
+    pub(crate) spooling_encoding: Option<String>,
 }
 
 impl SessionBuilder {
@@ -86,6 +88,7 @@ impl SessionBuilder {
             transaction_id: TransactionId::NoTransaction,
             client_request_timeout: Duration::from_secs(30),
             compression_disabled: false,
+            spooling_encoding: Some("json+zstd".to_string()),
         }
     }
 
@@ -118,6 +121,7 @@ impl SessionBuilder {
             transaction_id: self.transaction_id,
             client_request_timeout: self.client_request_timeout,
             compression_disabled: self.compression_disabled,
+            spooling_encoding: self.spooling_encoding,
         };
         Ok(ret)
     }

--- a/src/spooling/decoder.rs
+++ b/src/spooling/decoder.rs
@@ -1,0 +1,165 @@
+use crate::error::Error;
+use crate::spooling::SpoolingEncoding;
+use base64::prelude::*;
+use std::convert::TryFrom;
+use std::io::Read;
+use zstd::stream::Decoder;
+/// Decompress already-decoded segment bytes based on encoding
+pub fn decompress_segment_bytes(
+    compressed_data: &[u8],
+    encoding: &SpoolingEncoding,
+) -> Result<String, Error> {
+    decompress_bytes_internal(compressed_data, encoding)
+}
+
+/// Decode and decompress inline segment data
+pub fn decode_inline_segment(encoded_data: &str, encoding: &str) -> Result<String, Error> {
+    let encoding = SpoolingEncoding::try_from(encoding)?;
+
+    let compressed_data = BASE64_STANDARD
+        .decode(encoded_data)
+        .map_err(|e| Error::InternalError(format!("Failed to base64 decode segment: {}", e)))?;
+
+    decompress_bytes_internal(&compressed_data, &encoding)
+}
+
+/// Internal helper to decompress bytes with fallback logic
+/// If the decompression fails, we fallback to plain JSON
+/// If the fallback fails, we return the error
+fn decompress_bytes_internal(
+    compressed_data: &[u8],
+    encoding: &SpoolingEncoding,
+) -> Result<String, Error> {
+    let decompressed_data = match encoding {
+        SpoolingEncoding::JsonZstd => decompress_zstd(compressed_data).or_else(|e| {
+            let fallback_result = String::from_utf8(compressed_data.to_vec()).map_err(|utf8_err| {
+                Error::InternalError(format!(
+                    "Failed to decompress zstd and plain JSON fallback also failed: {}, {}",
+                    e, utf8_err
+                ))
+            });
+            fallback_result
+        })?,
+        SpoolingEncoding::JsonLz4 => decompress_lz4(compressed_data).or_else(|e| {
+            String::from_utf8(compressed_data.to_vec()).map_err(|utf8_err| {
+                Error::InternalError(format!(
+                    "Failed to decompress lz4 and plain JSON fallback also failed: {}, {}",
+                    e, utf8_err
+                ))
+            })
+        })?,
+        SpoolingEncoding::Json => String::from_utf8(compressed_data.to_vec()).map_err(|e| {
+            Error::InternalError(format!(
+                "Failed to convert uncompressed data to UTF-8: {}",
+                e
+            ))
+        })?,
+    };
+
+    Ok(decompressed_data)
+}
+
+/// Decompress zstd-compressed data
+fn decompress_zstd(compressed_data: &[u8]) -> Result<String, Error> {
+    let mut decoder = match Decoder::new(compressed_data) {
+        Ok(d) => d,
+        Err(e) => {
+            return Err(Error::InternalError(format!(
+                "Failed to create zstd decoder: {}",
+                e
+            )));
+        }
+    };
+
+    let mut decompressed = String::new();
+    match decoder.read_to_string(&mut decompressed) {
+        Ok(_) => Ok(decompressed),
+        Err(e) => Err(Error::InternalError(format!(
+            "Failed to decompress zstd data: {}",
+            e
+        ))),
+    }
+}
+
+/// Decompress lz4-compressed data
+fn decompress_lz4(compressed_data: &[u8]) -> Result<String, Error> {
+    let mut decoder = lz4::Decoder::new(compressed_data)
+        .map_err(|e| Error::InternalError(format!("Failed to create lz4 decoder: {}", e)))?;
+
+    let mut decompressed = String::new();
+    decoder
+        .read_to_string(&mut decompressed)
+        .map_err(|e| Error::InternalError(format!("Failed to decompress lz4 data: {}", e)))?;
+
+    Ok(decompressed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_uncompressed_json() {
+        // "[[1,2],[3,4]]" as base64
+        let encoded = "W1sxLDJdLFszLDRdXQ==";
+        let result = decode_inline_segment(encoded, "json").unwrap();
+        assert_eq!(result, "[[1,2],[3,4]]");
+    }
+
+    #[test]
+    fn test_decode_zstd_compressed() {
+        // Create a zstd-compressed version of "[[1,2],[3,4]]"
+        let original = "[[1,2],[3,4]]";
+        let compressed = zstd::encode_all(original.as_bytes(), 3).unwrap();
+        let encoded = BASE64_STANDARD.encode(&compressed);
+
+        let result = decode_inline_segment(&encoded, "json+zstd").unwrap();
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn test_decode_lz4_compressed() {
+        // Create an lz4-compressed version of "[[1,2],[3,4]]"
+        let original = "[[1,2],[3,4]]";
+        let mut encoder = lz4::EncoderBuilder::new().build(Vec::new()).unwrap();
+        std::io::Write::write_all(&mut encoder, original.as_bytes()).unwrap();
+        let (compressed, _result) = encoder.finish();
+        let encoded = BASE64_STANDARD.encode(&compressed);
+
+        let result = decode_inline_segment(&encoded, "json+lz4").unwrap();
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn test_invalid_base64() {
+        let result = decode_inline_segment("not!valid!base64!", "json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_unsupported_encoding() {
+        let encoded = "W1sxLDJdXQ==";
+        let result = decode_inline_segment(encoded, "unknown");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unsupported spooling encoding"));
+    }
+
+    #[test]
+    fn test_zstd_fallback_to_plain_json() {
+        let plain_json = "[[2,\"data\"]]";
+        let encoded = BASE64_STANDARD.encode(plain_json.as_bytes());
+        let result = decode_inline_segment(&encoded, "json+zstd").unwrap();
+        assert_eq!(result, plain_json);
+    }
+
+    #[test]
+    fn test_lz4_fallback_to_plain_json() {
+        let plain_json = "[[1,\"test\"]]";
+        let encoded = BASE64_STANDARD.encode(plain_json.as_bytes());
+        let result = decode_inline_segment(&encoded, "json+lz4").unwrap();
+        assert_eq!(result, plain_json);
+    }
+}

--- a/src/spooling/encoding.rs
+++ b/src/spooling/encoding.rs
@@ -1,0 +1,104 @@
+use std::convert::TryFrom;
+use std::fmt;
+
+use crate::error::{Error, Result};
+
+/// Spooling encoding format for Trino query data
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SpoolingEncoding {
+    /// Uncompressed JSON
+    Json,
+    /// JSON with Zstandard compression
+    JsonZstd,
+    /// JSON with LZ4 compression
+    JsonLz4,
+}
+
+impl SpoolingEncoding {
+    /// Get the string representation of the encoding
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SpoolingEncoding::Json => "json",
+            SpoolingEncoding::JsonZstd => "json+zstd",
+            SpoolingEncoding::JsonLz4 => "json+lz4",
+        }
+    }
+
+    /// Check if this encoding uses compression
+    pub fn is_compressed(self) -> bool {
+        matches!(self, SpoolingEncoding::JsonZstd | SpoolingEncoding::JsonLz4)
+    }
+}
+
+// Try to convert a string to a SpoolingEncoding
+impl TryFrom<&str> for SpoolingEncoding {
+    type Error = Error;
+
+    fn try_from(s: &str) -> Result<Self> {
+        match s {
+            "json" => Ok(SpoolingEncoding::Json),
+            "json+zstd" => Ok(SpoolingEncoding::JsonZstd),
+            "json+lz4" => Ok(SpoolingEncoding::JsonLz4),
+            _ => Err(Error::InternalError(format!(
+                "Unsupported spooling encoding: {}. Supported values: json, json+zstd, json+lz4",
+                s
+            ))),
+        }
+    }
+}
+
+impl fmt::Display for SpoolingEncoding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl From<SpoolingEncoding> for String {
+    fn from(encoding: SpoolingEncoding) -> Self {
+        encoding.as_str().to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn test_encoding_try_from() {
+        assert_eq!(
+            SpoolingEncoding::try_from("json").unwrap(),
+            SpoolingEncoding::Json
+        );
+        assert_eq!(
+            SpoolingEncoding::try_from("json+zstd").unwrap(),
+            SpoolingEncoding::JsonZstd
+        );
+        assert_eq!(
+            SpoolingEncoding::try_from("json+lz4").unwrap(),
+            SpoolingEncoding::JsonLz4
+        );
+        assert!(SpoolingEncoding::try_from("unknown").is_err());
+    }
+
+    #[test]
+    fn test_encoding_as_str() {
+        assert_eq!(SpoolingEncoding::Json.as_str(), "json");
+        assert_eq!(SpoolingEncoding::JsonZstd.as_str(), "json+zstd");
+        assert_eq!(SpoolingEncoding::JsonLz4.as_str(), "json+lz4");
+    }
+
+    #[test]
+    fn test_encoding_display() {
+        assert_eq!(SpoolingEncoding::Json.to_string(), "json");
+        assert_eq!(SpoolingEncoding::JsonZstd.to_string(), "json+zstd");
+        assert_eq!(SpoolingEncoding::JsonLz4.to_string(), "json+lz4");
+    }
+
+    #[test]
+    fn test_encoding_is_compressed() {
+        assert!(!SpoolingEncoding::Json.is_compressed());
+        assert!(SpoolingEncoding::JsonZstd.is_compressed());
+        assert!(SpoolingEncoding::JsonLz4.is_compressed());
+    }
+}

--- a/src/spooling/fetcher.rs
+++ b/src/spooling/fetcher.rs
@@ -1,0 +1,231 @@
+use std::collections::HashMap;
+use std::io::Read;
+
+use crate::error::{Error, Result};
+use crate::spooling::segment::Segment;
+use crate::spooling::segment::Segment::Inlined;
+use base64::{engine::general_purpose, Engine as _};
+use flate2::read::GzDecoder;
+use futures::stream::{self, StreamExt};
+use reqwest::Client;
+
+// Default maximum number of concurrent segment fetches
+const DEFAULT_MAX_CONCURRENT_SEGMENTS: usize = 5;
+
+// Fetcher for segments with the spooling protocol
+pub struct SegmentFetcher {
+    http_client: Client,
+    max_concurrent_segments: usize,
+}
+
+// Fetcher for segments
+impl SegmentFetcher {
+    pub fn new(http_client: Client) -> Self {
+        Self {
+            http_client,
+            max_concurrent_segments: DEFAULT_MAX_CONCURRENT_SEGMENTS,
+        }
+    }
+
+    /// Configure the maximum number of concurrent segment fetches
+    /// Default is 5
+    pub fn with_max_concurrent(mut self, count: usize) -> Self {
+        self.max_concurrent_segments = count.max(1);
+        self
+    }
+
+    /// Fetch a single segment and return the decoded data
+    pub async fn fetch_segment(&self, segment: &Segment) -> Result<Vec<u8>> {
+        match segment {
+            Inlined { data, .. } => self.fetch_inline_segment(data).await,
+            Segment::Spooled {
+                uri,
+                ack_uri,
+                headers,
+                ..
+            } => {
+                let data = self.fetch_spooled_segment(uri, headers.as_ref()).await?;
+
+                // Acknowledge the segment if ackUri is provided
+                if let Some(ack) = ack_uri {
+                    if let Err(e) = self.acknowledge_segment(ack, headers.as_ref()).await {
+                        log::warn!("Failed to acknowledge segment {}: {}", ack, e);
+                    }
+                }
+
+                Ok(data)
+            }
+        }
+    }
+
+    /// Fetch multiple segments with controlled concurrency
+    /// Uses buffered concurrency to limit the number of concurrent fetches
+    pub async fn fetch_segments(&self, segments: Vec<Segment>) -> Result<Vec<Vec<u8>>> {
+        log::debug!(
+            "Fetching {} segments with max concurrency of {}",
+            segments.len(),
+            self.max_concurrent_segments
+        );
+
+        let results: Vec<Result<Vec<u8>>> = stream::iter(segments.into_iter().enumerate())
+            .map(|(idx, segment)| async move {
+                self.fetch_segment(&segment).await.map_err(|e| {
+                    // Add context about which segment failed
+                    let segment_info = match &segment {
+                        Inlined { .. } => format!("inline segment #{}", idx),
+                        Segment::Spooled { uri, .. } => {
+                            format!("remote segment #{} (URI: {})", idx, uri)
+                        }
+                    };
+                    Error::InternalError(format!("Failed to fetch {}: {}", segment_info, e))
+                })
+            })
+            .buffer_unordered(self.max_concurrent_segments)
+            .collect()
+            .await;
+
+        // Collect results, returning early on first error
+        results.into_iter().collect()
+    }
+
+    // Fetch an inline segment
+    async fn fetch_inline_segment(&self, data: &str) -> Result<Vec<u8>> {
+        general_purpose::STANDARD
+            .decode(data)
+            .map_err(|e| Error::InternalError(format!("Base64 decode failed: {}", e)))
+    }
+
+    // Fetch a spooled segment (official Trino format)
+    // Supports optional ackUri and headers fields
+    async fn fetch_spooled_segment(
+        &self,
+        uri: &str,
+        headers: Option<&HashMap<String, Vec<String>>>,
+    ) -> Result<Vec<u8>> {
+        log::debug!("Fetching spooled segment from: {}", uri);
+
+        // Build GET request with optional headers
+        let mut request = self.http_client.get(uri);
+
+        // Apply headers if provided
+        if let Some(headers_map) = headers {
+            for (key, values) in headers_map {
+                for value in values {
+                    request = request.header(key, value);
+                }
+            }
+        }
+
+        // Execute GET request to the signed URI
+        // NOTE: For local Docker testing, the client must be able to resolve
+        // the storage hostname (e.g., 'minio') used in the URI. In production,
+        // clients and Trino should share the same network view of storage endpoints.
+        let response = request.send().await.map_err(|e| {
+            Error::InternalError(format!(
+                "Failed to fetch remote segment from {}: {}",
+                uri, e
+            ))
+        })?;
+
+        // Check status
+        if !response.status().is_success() {
+            return Err(Error::HttpNotOk(
+                response.status(),
+                format!("Failed to fetch segment from {}", uri),
+            ));
+        }
+
+        // Detect Content-Encoding from response headers
+        let content_encoding = response
+            .headers()
+            .get("content-encoding")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "identity".to_string());
+
+        log::debug!(
+            "Remote segment Content-Encoding: {} from {}",
+            content_encoding,
+            uri
+        );
+
+        // Get response body
+        let compressed_data = response
+            .bytes()
+            .await
+            .map_err(|e| Error::InternalError(format!("Failed to read response body: {}", e)))?;
+
+        // Decompress based on Content-Encoding header
+        let decompressed_data = match content_encoding.to_lowercase().as_str() {
+            "gzip" => {
+                log::debug!("Decompressing gzip content");
+                decompress_gzip(&compressed_data)?
+            }
+            "identity" | "" => compressed_data.to_vec(),
+            other => {
+                log::warn!(
+                    "Unknown Content-Encoding '{}', treating as uncompressed",
+                    other
+                );
+                compressed_data.to_vec()
+            }
+        };
+
+        log::info!(
+            "Successfully fetched remote spooled segment: {} bytes",
+            decompressed_data.len()
+        );
+
+        Ok(decompressed_data)
+    }
+
+    /// Acknowledge a segment after successful download
+    /// This is best-effort and non-fatal - failures are logged but don't prevent data retrieval
+    async fn acknowledge_segment(
+        &self,
+        ack_uri: &str,
+        headers: Option<&HashMap<String, Vec<String>>>,
+    ) -> Result<()> {
+        log::debug!("Acknowledging segment: {}", ack_uri);
+
+        let mut request = self.http_client.post(ack_uri);
+
+        // Apply headers if provided
+        if let Some(headers_map) = headers {
+            for (key, values) in headers_map {
+                for value in values {
+                    request = request.header(key, value);
+                }
+            }
+        }
+
+        let response = request.send().await.map_err(|e| {
+            Error::InternalError(format!(
+                "Failed to send acknowledgment to {}: {}",
+                ack_uri, e
+            ))
+        })?;
+
+        if !response.status().is_success() {
+            log::warn!(
+                "Acknowledgment returned non-success status: {} for {}",
+                response.status(),
+                ack_uri
+            );
+        }
+
+        Ok(())
+    }
+}
+
+/// Decompress gzip-compressed data
+fn decompress_gzip(compressed_data: &[u8]) -> Result<Vec<u8>> {
+    let mut decoder = GzDecoder::new(compressed_data);
+    let mut decompressed = Vec::new();
+
+    decoder
+        .read_to_end(&mut decompressed)
+        .map_err(|e| Error::InternalError(format!("Failed to decompress gzip data: {}", e)))?;
+
+    Ok(decompressed)
+}

--- a/src/spooling/fetcher.rs
+++ b/src/spooling/fetcher.rs
@@ -86,7 +86,7 @@ impl SegmentFetcher {
                     Error::InternalError(format!("Failed to fetch {}: {}", segment_info, e))
                 })
             })
-            .buffer_unordered(self.max_concurrent_segments)
+            .buffered(self.max_concurrent_segments)
             .collect()
             .await;
 

--- a/src/spooling/mod.rs
+++ b/src/spooling/mod.rs
@@ -1,0 +1,9 @@
+mod decoder;
+mod encoding;
+mod fetcher;
+mod segment;
+
+pub use decoder::{decode_inline_segment, decompress_segment_bytes};
+pub use encoding::SpoolingEncoding;
+pub use fetcher::SegmentFetcher;
+pub use segment::Segment;

--- a/src/spooling/segment.rs
+++ b/src/spooling/segment.rs
@@ -1,0 +1,273 @@
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+
+// Data attributes for a segment
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DataAttributes {
+    #[serde(flatten)]
+    attributes: HashMap<String, serde_json::Value>,
+}
+
+// Data attributes for a segment
+impl DataAttributes {
+    // Get the row offset for a segment
+    pub fn row_offset(&self) -> Option<u64> {
+        self.attributes.get("rowOffset")?.as_u64()
+    }
+
+    // Get the number of rows for a segment
+    pub fn rows_count(&self) -> Option<u64> {
+        self.attributes.get("rowsCount")?.as_u64()
+    }
+
+    // Get the size of a segment
+    pub fn segment_size(&self) -> Option<u64> {
+        self.attributes.get("segmentSize")?.as_u64()
+    }
+}
+
+// Segment is a part of a query result when using the spooling protocol
+#[derive(Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum Segment {
+    // Inlined segment
+    Inlined {
+        #[serde(rename = "type")]
+        segment_type: String,
+        data: String,
+        metadata: DataAttributes,
+    },
+    // Spooled segment
+    Spooled {
+        #[serde(rename = "type")]
+        segment_type: String,
+        uri: String,
+        #[serde(rename = "ackUri")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        ack_uri: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        headers: Option<HashMap<String, Vec<String>>>,
+        metadata: DataAttributes,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_inlined_segment() {
+        let json = r#"{
+            "type": "inline",
+            "data": "SGVsbG8gV29ybGQ=",
+            "metadata": {
+                "rowOffset": 0,
+                "rowsCount": 1,
+                "segmentSize": 1024
+            }
+        }"#;
+        let segment: Segment = serde_json::from_str(json).unwrap();
+        match segment {
+            Segment::Inlined {
+                segment_type,
+                data,
+                metadata,
+            } => {
+                assert_eq!(segment_type, "inline");
+                assert_eq!(data, "SGVsbG8gV29ybGQ=");
+                assert_eq!(metadata.row_offset(), Some(0));
+                assert_eq!(metadata.rows_count(), Some(1));
+                assert_eq!(metadata.segment_size(), Some(1024));
+            }
+            _ => panic!("Expected Inlined segment"),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_spooled_segment_minimal() {
+        let json = r#"{
+            "type": "spooled",
+            "uri": "http://minio:9000/bucket/segment.json?signature=abc123",
+            "metadata": {
+                "rowOffset": 0,
+                "rowsCount": 1000,
+                "segmentSize": 1048576
+            }
+        }"#;
+        let segment: Segment = serde_json::from_str(json).unwrap();
+        match segment {
+            Segment::Spooled {
+                segment_type,
+                uri,
+                ack_uri,
+                headers,
+                metadata,
+            } => {
+                assert_eq!(segment_type, "spooled");
+                assert_eq!(
+                    uri,
+                    "http://minio:9000/bucket/segment.json?signature=abc123"
+                );
+                assert_eq!(ack_uri, None);
+                assert_eq!(headers, None);
+                assert_eq!(metadata.row_offset(), Some(0));
+                assert_eq!(metadata.rows_count(), Some(1000));
+                assert_eq!(metadata.segment_size(), Some(1048576));
+            }
+            _ => panic!("Expected Spooled segment"),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_spooled_segment_with_ack() {
+        let json = r#"{
+            "type": "spooled",
+            "uri": "http://minio:9000/bucket/segment.json",
+            "ackUri": "http://minio:9000/bucket/segment.ack",
+            "headers": {
+                "X-Custom": ["value1"]
+            },
+            "metadata": {
+                "rowOffset": 0,
+                "rowsCount": 100
+            }
+        }"#;
+        let segment: Segment = serde_json::from_str(json).unwrap();
+        match segment {
+            Segment::Spooled {
+                segment_type,
+                uri,
+                ack_uri,
+                headers,
+                metadata,
+            } => {
+                assert_eq!(segment_type, "spooled");
+                assert_eq!(uri, "http://minio:9000/bucket/segment.json");
+                assert_eq!(
+                    ack_uri,
+                    Some("http://minio:9000/bucket/segment.ack".to_string())
+                );
+                assert!(headers.is_some());
+                assert_eq!(metadata.row_offset(), Some(0));
+                assert_eq!(metadata.rows_count(), Some(100));
+            }
+            _ => panic!("Expected Spooled segment"),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_inlined_segment_minimal() {
+        let json = r#"{
+            "type": "inline",
+            "data": "YWJjZGVmZw==",
+            "metadata": {}
+        }"#;
+        let segment: Segment = serde_json::from_str(json).unwrap();
+        match segment {
+            Segment::Inlined {
+                segment_type,
+                data,
+                metadata,
+            } => {
+                assert_eq!(segment_type, "inline");
+                assert_eq!(data, "YWJjZGVmZw==");
+                assert_eq!(metadata.row_offset(), None);
+                assert_eq!(metadata.rows_count(), None);
+                assert_eq!(metadata.segment_size(), None);
+            }
+            _ => panic!("Expected Inlined segment"),
+        }
+    }
+
+    #[test]
+    fn test_data_attributes_row_offset() {
+        let json = r#"{
+            "rowOffset": 42
+        }"#;
+        let data_attributes: DataAttributes = serde_json::from_str(json).unwrap();
+        assert_eq!(data_attributes.row_offset(), Some(42));
+        assert_eq!(data_attributes.rows_count(), None);
+        assert_eq!(data_attributes.segment_size(), None);
+    }
+
+    #[test]
+    fn test_data_attributes_rows_count() {
+        let json = r#"{
+            "rowsCount": 100
+        }"#;
+        let data_attributes: DataAttributes = serde_json::from_str(json).unwrap();
+        assert_eq!(data_attributes.row_offset(), None);
+        assert_eq!(data_attributes.rows_count(), Some(100));
+        assert_eq!(data_attributes.segment_size(), None);
+    }
+
+    #[test]
+    fn test_data_attributes_segment_size() {
+        let json = r#"{
+            "segmentSize": 4096
+        }"#;
+        let data_attributes: DataAttributes = serde_json::from_str(json).unwrap();
+        assert_eq!(data_attributes.row_offset(), None);
+        assert_eq!(data_attributes.rows_count(), None);
+        assert_eq!(data_attributes.segment_size(), Some(4096));
+    }
+
+    #[test]
+    fn test_data_attributes_all_fields() {
+        let json = r#"{
+            "rowOffset": 0,
+            "rowsCount": 10,
+            "segmentSize": 512
+        }"#;
+        let data_attributes: DataAttributes = serde_json::from_str(json).unwrap();
+        assert_eq!(data_attributes.row_offset(), Some(0));
+        assert_eq!(data_attributes.rows_count(), Some(10));
+        assert_eq!(data_attributes.segment_size(), Some(512));
+    }
+
+    #[test]
+    fn test_spooled_segment_with_multiple_header_values() {
+        let json = r#"{
+            "type": "spooled",
+            "uri": "http://storage/segment.json",
+            "ackUri": "http://storage/segment.ack",
+            "headers": {
+                "Authorization": ["Bearer token123"],
+                "X-Custom": ["value1", "value2"]
+            },
+            "metadata": {
+                "rowOffset": 100,
+                "rowsCount": 50
+            }
+        }"#;
+        let segment: Segment = serde_json::from_str(json).unwrap();
+
+        match segment {
+            Segment::Spooled {
+                uri,
+                ack_uri,
+                headers,
+                metadata,
+                ..
+            } => {
+                assert_eq!(uri, "http://storage/segment.json");
+                assert_eq!(ack_uri, Some("http://storage/segment.ack".to_string()));
+                assert!(headers.is_some());
+                let headers_map = headers.unwrap();
+                assert_eq!(
+                    headers_map.get("Authorization"),
+                    Some(&vec!["Bearer token123".to_string()])
+                );
+                assert_eq!(
+                    headers_map.get("X-Custom"),
+                    Some(&vec!["value1".to_string(), "value2".to_string()])
+                );
+                assert_eq!(metadata.row_offset(), Some(100));
+                assert_eq!(metadata.rows_count(), Some(50));
+            }
+            _ => panic!("Expected Spooled segment"),
+        }
+    }
+}

--- a/src/types/row.rs
+++ b/src/types/row.rs
@@ -49,7 +49,6 @@ impl<'de> DeserializeSeed<'de> for RowSeed {
     }
 }
 
-// Also implement Deserialize directly for Row
 impl<'de> Deserialize<'de> for Row {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/types/row.rs
+++ b/src/types/row.rs
@@ -1,9 +1,10 @@
 use serde::de::{Deserialize, DeserializeSeed, Deserializer};
+use serde::Serialize;
 use serde_json::Value;
 
 use crate::{Context, Trino, TrinoTy};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Row {
     data: Vec<Value>,
 }
@@ -40,6 +41,17 @@ pub struct RowSeed;
 impl<'de> DeserializeSeed<'de> for RowSeed {
     type Value = Row;
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let data = <Vec<Value>>::deserialize(deserializer)?;
+        Ok(Row { data })
+    }
+}
+
+// Also implement Deserialize directly for Row
+impl<'de> Deserialize<'de> for Row {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {

--- a/tests/spooling_protocol.rs
+++ b/tests/spooling_protocol.rs
@@ -1,0 +1,242 @@
+use trino_rust_client::models::{QueryResult, QueryResultData};
+use trino_rust_client::Trino;
+
+#[derive(Trino, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+struct TestRecord {
+    id: i64,
+    name: String,
+}
+
+#[test]
+fn test_spooled_data_deserialization() {
+    let json = r#"{
+        "id": "test-query-id",
+        "infoUri": "http://localhost:8080/v1/query/test-query-id",
+        "nextUri": null,
+        "columns": [
+            {
+                "name": "id",
+                "type": "bigint",
+                "typeSignature": {
+                    "rawType": "bigint",
+                    "arguments": []
+                }
+            },
+            {
+                "name": "name",
+                "type": "varchar",
+                "typeSignature": {
+                    "rawType": "varchar",
+                    "arguments": []
+                }
+            }
+        ],
+        "data": {
+            "encoding": "json",
+            "segments": [
+                {
+                    "data": "W3siaWQiOjEsIm5hbWUiOiJhbGljZSJ9XQ==",
+                    "metadata": {}
+                },
+                {
+                    "data": "W3siaWQiOjIsIm5hbWUiOiJib2IifV0=",
+                    "metadata": {}
+                }
+            ]
+        },
+        "stats": {
+            "state": "FINISHED",
+            "queued": false,
+            "scheduled": true,
+            "nodes": 1,
+            "totalSplits": 1,
+            "queuedSplits": 0,
+            "runningSplits": 0,
+            "completedSplits": 1,
+            "cpuTimeMillis": 0,
+            "wallTimeMillis": 0,
+            "queuedTimeMillis": 0,
+            "elapsedTimeMillis": 0,
+            "processedRows": 2,
+            "processedBytes": 0,
+            "peakMemoryBytes": 0,
+            "spilledBytes": 0
+        },
+        "warnings": []
+    }"#;
+    let result: QueryResult<TestRecord> = serde_json::from_str(json).unwrap();
+
+    assert!(matches!(result.data, Some(QueryResultData::Spooled(_))));
+    assert_eq!(result.columns.unwrap().len(), 2);
+
+    let records = result.data.unwrap().into_vec();
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0].id, 1);
+    assert_eq!(records[0].name, "alice");
+    assert_eq!(records[1].id, 2);
+    assert_eq!(records[1].name, "bob");
+}
+
+#[test]
+fn test_direct_protocol_fallback() {
+    let json = r#"{
+        "id": "test-query-id",
+        "infoUri": "http://localhost:8080/v1/query/test-query-id",
+        "nextUri": null,
+        "columns": [
+            {
+                "name": "id",
+                "type": "bigint",
+                "typeSignature": {
+                    "rawType": "bigint",
+                    "arguments": []
+                }
+            },
+            {
+                "name": "name",
+                "type": "varchar",
+                "typeSignature": {
+                    "rawType": "varchar",
+                    "arguments": []
+                }
+            }
+        ],
+        "data": [
+            {"id": 1, "name": "alice"},
+            {"id": 2, "name": "bob"}
+        ],
+        "stats": {
+            "state": "FINISHED",
+            "queued": false,
+            "scheduled": true,
+            "nodes": 1,
+            "totalSplits": 1,
+            "queuedSplits": 0,
+            "runningSplits": 0,
+            "completedSplits": 1,
+            "cpuTimeMillis": 0,
+            "wallTimeMillis": 0,
+            "queuedTimeMillis": 0,
+            "elapsedTimeMillis": 0,
+            "processedRows": 2,
+            "processedBytes": 0,
+            "peakMemoryBytes": 0,
+            "spilledBytes": 0
+        },
+        "warnings": []
+    }"#;
+    let result: QueryResult<TestRecord> = serde_json::from_str(json).unwrap();
+
+    assert!(matches!(result.data, Some(QueryResultData::Direct(_))));
+    if let Some(QueryResultData::Direct(data)) = result.data {
+        assert_eq!(data.len(), 2);
+        assert_eq!(data[0].id, 1);
+        assert_eq!(data[0].name, "alice");
+    }
+}
+
+#[test]
+fn test_mixed_protocol_detection() {
+    let spooled_json = r#"{
+        "id": "test-query-id",
+        "infoUri": "http://localhost:8080/v1/query/test-query-id",
+        "nextUri": null,
+        "columns": [
+            {
+                "name": "id",
+                "type": "bigint",
+                "typeSignature": {
+                    "rawType": "bigint",
+                    "arguments": []
+                }
+            },
+            {
+                "name": "name",
+                "type": "varchar",
+                "typeSignature": {
+                    "rawType": "varchar",
+                    "arguments": []
+                }
+            }
+        ],
+        "data": {
+            "encoding": "json",
+            "segments": [
+                {
+                    "data": "W3siaWQiOjEsIm5hbWUiOiJhbGljZSJ9XQ==",
+                    "metadata": {}
+                }
+            ]
+        },
+        "stats": {
+            "state": "FINISHED",
+            "queued": false,
+            "scheduled": true,
+            "nodes": 1,
+            "totalSplits": 1,
+            "queuedSplits": 0,
+            "runningSplits": 0,
+            "completedSplits": 1,
+            "cpuTimeMillis": 0,
+            "wallTimeMillis": 0,
+            "queuedTimeMillis": 0,
+            "elapsedTimeMillis": 0,
+            "processedRows": 1,
+            "processedBytes": 0,
+            "peakMemoryBytes": 0,
+            "spilledBytes": 0
+        },
+        "warnings": []
+    }"#;
+    let direct_json = r#"{
+        "id": "test-query-id",
+        "infoUri": "http://localhost:8080/v1/query/test-query-id",
+        "nextUri": null,
+        "columns": [
+            {
+                "name": "id",
+                "type": "bigint",
+                "typeSignature": {
+                    "rawType": "bigint",
+                    "arguments": []
+                }
+            },
+            {
+                "name": "name",
+                "type": "varchar",
+                "typeSignature": {
+                    "rawType": "varchar",
+                    "arguments": []
+                }
+            }
+        ],
+        "data": [
+            {"id": 1, "name": "alice"}
+        ],
+        "stats": {
+            "state": "FINISHED",
+            "queued": false,
+            "scheduled": true,
+            "nodes": 1,
+            "totalSplits": 1,
+            "queuedSplits": 0,
+            "runningSplits": 0,
+            "completedSplits": 1,
+            "cpuTimeMillis": 0,
+            "wallTimeMillis": 0,
+            "queuedTimeMillis": 0,
+            "elapsedTimeMillis": 0,
+            "processedRows": 1,
+            "processedBytes": 0,
+            "peakMemoryBytes": 0,
+            "spilledBytes": 0
+        },
+        "warnings": []
+    }"#;
+
+    let spooled: QueryResult<TestRecord> = serde_json::from_str(spooled_json).unwrap();
+    let direct: QueryResult<TestRecord> = serde_json::from_str(direct_json).unwrap();
+
+    assert!(matches!(spooled.data, Some(QueryResultData::Spooled(_))));
+    assert!(matches!(direct.data, Some(QueryResultData::Direct(_))));
+}

--- a/tests/spooling_protocol.rs
+++ b/tests/spooling_protocol.rs
@@ -35,10 +35,12 @@ fn test_spooled_data_deserialization() {
             "encoding": "json",
             "segments": [
                 {
+                    "type": "inline",
                     "data": "W3siaWQiOjEsIm5hbWUiOiJhbGljZSJ9XQ==",
                     "metadata": {}
                 },
                 {
+                    "type": "inline",
                     "data": "W3siaWQiOjIsIm5hbWUiOiJib2IifV0=",
                     "metadata": {}
                 }
@@ -163,6 +165,7 @@ fn test_mixed_protocol_detection() {
             "encoding": "json",
             "segments": [
                 {
+                    "type": "inline",
                     "data": "W3siaWQiOjEsIm5hbWUiOiJhbGljZSJ9XQ==",
                     "metadata": {}
                 }

--- a/trino-rust-client-macros/Cargo.toml
+++ b/trino-rust-client-macros/Cargo.toml
@@ -7,13 +7,13 @@ syn = {version = "2.0.104", features = ["default", "extra-traits", "full"]}
 proc-macro = true
 
 [package]
-authors = ["nudibranches technologies <contact@nudibranches.tech>"]
+authors = {workspace = true}
 description = "trino rust client macros"
-documentation = "https://docs.rs/trino-rust-client"
-edition = "2021"
-homepage = "https://github.com/nudibranches-tech/trino-rust-client"
+documentation = {workspace = true}
+edition = {workspace = true}
+homepage = {workspace = true}
 keywords = ["trino"]
-license = "MIT"
+license = {workspace = true}
 name = "trino-rust-client-macros"
-repository = "https://github.com/nudibranches-tech/trino-rust-client"
+repository = {workspace = true}
 version = "0.6.0"


### PR DESCRIPTION
# Summary
This PR adds complete support for [Trino's spooling protocol](https://trino.io/docs/current/client/client-protocol.html#spooling-protocol), enabling handling of large query results by fetching data from external storage instead of embedding it directly in HTTP responses.

This PR has been tested locally with Docker:
- With Trino Cluster Version `478`
- With and without spooling enabled

### Key Features

- Automatic protocol detection: the client automatically detects and handles both `Direct` and `Spooled` protocols based on server responses
- Segment fetching: supports fetching both inline (base64-encoded) and remote (HTTP) segments with concurrent request handling (maximum concurrent requests could be set)
- Compression support: automatic decompression for `json`, `json+zstd`, and `json-lz4` formats based on Content-Encoding headers
- Segment acknowledgment: optional acknowledgment support for remote segments

### Implementation Details

- Added `spooling` optional feature gate with compression dependencies (`zstd`, `lz4`, `flate2`, `base64`)
- New module with spooling: `spooling::fetcher`, `spooling::decoder`, `spooling::encoding`, `spooling::segment`
-`QueryResultData` enum to support both Direct and Spooled variants
- Configurable via `ClientBuilder`: `spooling_encoding()` and `max_concurrent_segments()`: when the encoding is set, the header is added, and the server decides when it's best to use the spooling protocol

### Usage

```
let client = ClientBuilder::new("user", "localhost")
    .spooling_encoding("json+zstd")
    .max_concurrent_segments(10)  // Default based on CPU
    .build()?;
```

`let dataset = client.get_all::<MyStruct>(sql).await?;`
The client automatically uses the spooling protocol when the server supports it, with seamless fallback to the `Direct` protocol otherwise.

### Breaking Changes

None - this is a backward-compatible feature addition.

### Follow-ups
Use streaming/chunked processing for very large datasets
