### PR TITLE
chore(ci): add a step for running the integration tests in the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,17 @@ jobs:
           command: check
           args: -Z features=dev_dep
 
-      - name: Run cargo test
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
+      - name: Run cargo test (unit tests with spooling feature)
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --workspace --exclude trino-integration-tests --features spooling
+
+      - name: Run integration tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --package trino-integration-tests


### PR DESCRIPTION
# Summary
The test suite, including Docker-based integration tests, now runs in CI to ensure full validation during each check.