### PR TITLE
Allow auth over http

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -46,7 +46,7 @@ pub struct Client {
 pub struct ClientBuilder {
     session: SessionBuilder,
     auth: Option<Auth>,
-    auth_http_insecure: false,
+    auth_http_insecure: bool,
     max_attempt: usize,
     ssl: Option<Ssl>,
     no_verify: bool,

--- a/src/client.rs
+++ b/src/client.rs
@@ -46,6 +46,7 @@ pub struct Client {
 pub struct ClientBuilder {
     session: SessionBuilder,
     auth: Option<Auth>,
+    auth_http_insecure: false,
     max_attempt: usize,
     ssl: Option<Ssl>,
     no_verify: bool,
@@ -68,6 +69,7 @@ impl ClientBuilder {
         Self {
             session: builder,
             auth: None,
+            auth_http_insecure: false,
             max_attempt: 3,
             ssl: None,
             no_verify: false,
@@ -237,6 +239,11 @@ impl ClientBuilder {
         self
     }
 
+    pub fn auth_http_insecure(mut self, ahi: bool) -> Self {
+        self.auth_http_insecure = ahi;
+        self
+    }
+
     pub fn max_attempt(mut self, s: usize) -> Self {
         self.max_attempt = s;
         self
@@ -251,7 +258,7 @@ impl ClientBuilder {
         let session = self.session.build()?;
         let max_attempt = self.max_attempt;
 
-        if self.auth.is_some() && session.url.scheme() == "http" {
+        if (self.auth.is_some() && session.url.scheme() == "http") && !self.auth_http_insecure {
             return Err(Error::BasicAuthWithHttp);
         }
 


### PR DESCRIPTION
This allows for users to auth over plaintext, for when you're terminating SSL at a loadbalancer but still have local clients that need to auth, for example within a Kubernetes cluster and using the JWT for federated workload identity.

The Trino setting this works with is: `http-server.authentication.allow-insecure-over-http=true`

Docs here: https://trino.io/docs/current/security/tls.html#configure-the-coordinator