### PR TITLE
refactor!: clean up cargo features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://book.async.rs/overview/stability-guarantees.html).
 
 ## [Unreleased]
+### Removed
+- **Breaking:** Removed the unused `Trino` feature [#40](https://github.com/nudibranches-tech/trino-rust-client/pull/40)
+- **Breaking:** The optional `spooling` codec dependencies (`base64`, `zstd`, `lz4`, `flate2`) are no longer exposed as standalone public features; they are now declared via `dep:` and can only be enabled through the `spooling` feature [#40](https://github.com/nudibranches-tech/trino-rust-client/pull/40)
 
 ## [0.9.3] - 2026-02-19
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,8 @@ path = "examples/spooling.rs"
 required-features = ["spooling"]
 
 [features]
-Trino = []
 default = []
-spooling = ["base64", "zstd", "lz4", "flate2"]
+spooling = ["dep:base64", "dep:zstd", "dep:lz4", "dep:flate2"]
 
 [package]
 authors = {workspace = true}


### PR DESCRIPTION
Remove the unused `Trino` feature and stop exposing the `spooling` codec dependencies as standalone public features.

The optional `base64`, `zstd`, `lz4` and `flate2` dependencies were referenced by bare name in the `spooling` feature, which implicitly created public features for each. None of them gate any code on their own — all spooling code is gated behind the `spooling` feature and uses all four codecs together — so enabling them individually only pulled in dead dependencies. Switch to `dep:` syntax so they can only be enabled via `spooling`.