### PR TITLE
chore(security): update dependencies to remediate RustSec advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://book.async.rs/overview/stability-guarantees.html).
 
 ## [Unreleased]
+### Security
+- Updated dependencies to remediate 13 RustSec advisories in transitive crates, including `aws-lc-sys` (X.509/PKCS7 validation bypasses, timing side-channel), `quinn-proto` (DoS, memory exhaustion), `rustls-webpki` (CRL/name-constraint validation, parsing panic), `bytes` (integer overflow) and `slab` (out-of-bounds, yanked)
+
+### Changed
+- Refreshed direct dependency versions (`backon`, `chrono`, `futures`, `http`, `log`, `regex`, `reqwest`, `serde_json`, `tokio`, `tracing-subscriber`, `uuid`)
+- Replaced the unmaintained `dotenv` dev-dependency with the maintained `dotenvy`
+
 ### Removed
 - **Breaking:** Removed the unused `Trino` feature [#40](https://github.com/nudibranches-tech/trino-rust-client/pull/40)
 - **Breaking:** The optional `spooling` codec dependencies (`base64`, `zstd`, `lz4`, `flate2`) are no longer exposed as standalone public features; they are now declared via `dep:` and can only be enabled through the `spooling` feature [#40](https://github.com/nudibranches-tech/trino-rust-client/pull/40)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## [Unreleased]
 ### Security
-- Updated dependencies to remediate 13 RustSec advisories in transitive crates, including `aws-lc-sys` (X.509/PKCS7 validation bypasses, timing side-channel), `quinn-proto` (DoS, memory exhaustion), `rustls-webpki` (CRL/name-constraint validation, parsing panic), `bytes` (integer overflow) and `slab` (out-of-bounds, yanked)
+- Updated dependencies to remediate 13 RustSec advisories in transitive crates, including `aws-lc-sys` (X.509/PKCS7 validation bypasses, timing side-channel), `quinn-proto` (DoS, memory exhaustion), `rustls-webpki` (CRL/name-constraint validation, parsing panic), `bytes` (integer overflow) and `slab` (out-of-bounds, yanked) [#44](https://github.com/nudibranches-tech/trino-rust-client/pull/44)
 
 ### Changed
-- Refreshed direct dependency versions (`backon`, `chrono`, `futures`, `http`, `log`, `regex`, `reqwest`, `serde_json`, `tokio`, `tracing-subscriber`, `uuid`)
-- Replaced the unmaintained `dotenv` dev-dependency with the maintained `dotenvy`
+- Refreshed direct dependency versions (`backon`, `chrono`, `futures`, `http`, `log`, `regex`, `reqwest`, `serde_json`, `tokio`, `tracing-subscriber`, `uuid`) [#44](https://github.com/nudibranches-tech/trino-rust-client/pull/44)
+- Replaced the unmaintained `dotenv` dev-dependency with the maintained `dotenvy` [#44](https://github.com/nudibranches-tech/trino-rust-client/pull/44)
 
 ### Removed
 - **Breaking:** Removed the unused `Trino` feature [#40](https://github.com/nudibranches-tech/trino-rust-client/pull/40)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ uuid = {workspace = true}
 zstd = {workspace = true, optional = true}
 
 [dev-dependencies]
-dotenv = "0.15"
+dotenvy = "0.15"
 maplit = "1.0"
 trybuild = "1.0.112"
 wiremock = "0.6.5"
@@ -64,30 +64,30 @@ required-features = ["spooling"]
 members = [".", "trino-rust-client-macros", "integration_tests"]
 
 [workspace.dependencies]
-backon = "1.5.2"
+backon = "1.6.0"
 base64 = "0.22"
 bigdecimal = "0.4.10"
-chrono = "0.4.43"
+chrono = "0.4.45"
 chrono-tz = "0.10.4"
 derive_more = {version = "2.1.1", features = ["full"]}
 flate2 = "1.1.9"
-futures = "0.3.32"
-http = "1.4"
+futures = "0.3.33"
+http = "1.4.2"
 iterable = "0.6"
 lazy_static = "1.5"
-log = "0.4.29"
+log = "0.4.33"
 lz4 = "1.28"
 paste = "1.0.15"
-regex = "1.12.3"
-reqwest = {version = "0.13.2", default-features = false, features = ["rustls", "json"]}
+regex = "1.13.1"
+reqwest = {version = "0.13.4", default-features = false, features = ["rustls", "json"]}
 serde = {version = "1.0", features = ["derive"]}
-serde_json = "1.0.149"
+serde_json = "1.0.150"
 thiserror = "2.0.18"
-tokio = {version = "1.49", features = ["full"]}
-tracing-subscriber = {version = "0.3.22", default-features = false, features = ["fmt", "env-filter"]}
+tokio = {version = "1.53", features = ["full"]}
+tracing-subscriber = {version = "0.3.23", default-features = false, features = ["fmt", "env-filter"]}
 trino-rust-client-macros = {version = "0.7.1", path = "trino-rust-client-macros"}
 url = "2.5.8"
-uuid = {version = "1.21.0", features = ["serde", "v4"]}
+uuid = {version = "1.24.0", features = ["serde", "v4"]}
 zstd = "0.13"
 
 [workspace.package]

--- a/examples/derive.rs
+++ b/examples/derive.rs
@@ -1,6 +1,6 @@
 use std::env::var;
 
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use serde::{Deserialize, Serialize};
 use trino_rust_client::{ClientBuilder, Trino};
 

--- a/examples/https.rs
+++ b/examples/https.rs
@@ -1,6 +1,6 @@
 use std::env::var;
 
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use trino_rust_client::auth::Auth;
 use trino_rust_client::ssl::Ssl;
 use trino_rust_client::{ClientBuilder, Row};

--- a/examples/jwt_auth.rs
+++ b/examples/jwt_auth.rs
@@ -1,6 +1,6 @@
 use std::env::var;
 
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use trino_rust_client::auth::Auth;
 use trino_rust_client::ssl::Ssl;
 use trino_rust_client::{ClientBuilder, Row};

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
 use std::env::var;
 
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use trino_rust_client::{ClientBuilder, Row};
 
 #[tokio::main]


### PR DESCRIPTION
## Contexte

`cargo audit` remontait **13 vulnérabilités** dans des dépendances **transitives** (via `reqwest` → stack `rustls`/`quinn`/`aws-lc`, `tokio` → `bytes`, etc.), plus des warnings *unmaintained*.

## Correctifs

Rafraîchissement des versions et du lockfile pour que les crates transitives se résolvent vers des releases patchées :

| Crate | Vuln | Sévérité max |
|---|---|---|
| `aws-lc-sys` 0.37.1 → 0.43.0 | 5 CVE (bypass X.509/PKCS7, timing side-channel) | 7.5 high |
| `quinn-proto` 0.11.12 → 0.11.16 | DoS + épuisement mémoire | 8.7 high |
| `rustls-webpki` 0.103.3 → 0.103.13 | 4 CVE (validation CRL/name-constraints, panic) | high |
| `bytes` 1.10.1 → 1.12.1 | integer overflow | — |
| `slab` 0.4.10 → 0.4.12 | OOB + version yanked | — |

Après mise à jour : **`cargo audit` = 0 vulnérabilité**.

### Autres changements
- Rafraîchissement des versions minimales des dépendances directes (`backon`, `chrono`, `futures`, `http`, `log`, `regex`, `reqwest`, `serde_json`, `tokio`, `tracing-subscriber`, `uuid`)
- Remplacement du dev-dependency non-maintenu `dotenv` par `dotenvy` (fork maintenu, drop-in)

> Note : `Cargo.lock` est gitignored (librairie) — le correctif pour les consommateurs passe par les planchers du manifest ; un resolve frais récupère déjà les versions transitives patchées.

## Vérifications
- ✅ `cargo check` (défaut + `--features spooling` + examples)
- ✅ `cargo test --features spooling` (tous les tests passent)
- ✅ `cargo clippy --all-features -D warnings`
- ✅ `cargo audit` : 0 vulnérabilité (reste `paste` unmaintained, non corrigeable)