### PR TITLE
feat: derive Serialize on model types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ### Added
 - Support configuring the name of the result field when using the `Trino` derive macro [#43](https://github.com/nudibranches-tech/trino-rust-client/pull/43)
+- Derive `Serialize` on the result, error, stat, warning and segment model types to allow serializing query results (credit to [@sbernauer](https://github.com/sbernauer), originally [#42](https://github.com/nudibranches-tech/trino-rust-client/pull/42))
 
 ## [0.9.3] - 2026-02-19
 ### Added

--- a/src/models/error.rs
+++ b/src/models/error.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryError {
     pub message: String,
@@ -14,14 +14,14 @@ pub struct QueryError {
     pub failure_info: FailureInfo,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ErrorLocation {
     pub line_number: u32,
     pub column_number: u32,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FailureInfo {
     #[serde(rename = "type")]

--- a/src/models/result.rs
+++ b/src/models/result.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use super::*;
@@ -9,7 +9,7 @@ use crate::spooling::{decode_inline_segment, Segment};
 use crate::Trino;
 
 /// Query result data can be either Direct (inline array) or Spooled (compressed segments)
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
 pub enum QueryResultData<T: Trino> {
@@ -43,7 +43,7 @@ where
 }
 
 /// Spooled data contains encoding format and segment references
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SpooledData {
     pub encoding: String,
@@ -85,7 +85,7 @@ impl SpooledData {
 }
 
 /// Metadata about spooled data segments
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DataAttributes {
     pub rows_count: Option<u64>,
@@ -95,7 +95,7 @@ pub struct DataAttributes {
 }
 
 /// Trino query result
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryResult<T: Trino> {
     pub id: String,

--- a/src/models/stat.rs
+++ b/src/models/stat.rs
@@ -1,6 +1,6 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Stat {
     pub state: String,
@@ -23,7 +23,7 @@ pub struct Stat {
     pub root_stage: Option<StageStats>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StageStats {
     //TODO: impl this

--- a/src/models/warning.rs
+++ b/src/models/warning.rs
@@ -1,13 +1,13 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Warning {
     pub warning_code: Code,
     pub message: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Code {
     pub code: i32,

--- a/src/spooling/segment.rs
+++ b/src/spooling/segment.rs
@@ -29,7 +29,7 @@ impl DataAttributes {
 }
 
 // Segment is a part of a query result when using the spooling protocol
-#[derive(Deserialize, Debug, PartialEq)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", untagged)]
 pub enum Segment {
     // Inlined segment

--- a/tests/get_all_empty.rs
+++ b/tests/get_all_empty.rs
@@ -67,7 +67,10 @@ async fn test_get_all_empty_result_set_row_type() {
     let (server, host, port) = make_mock_server().await;
     mount_empty_result_mocks(&server).await;
 
-    let client = ClientBuilder::new("test_user", host).port(port).build().unwrap();
+    let client = ClientBuilder::new("test_user", host)
+        .port(port)
+        .build()
+        .unwrap();
 
     let result = client
         .get_all::<Row>("SELECT a, b, c, d, e, f FROM t WHERE 1=0".to_string())
@@ -100,7 +103,10 @@ async fn test_get_all_empty_result_set_derived_type() {
     let (server, host, port) = make_mock_server().await;
     mount_empty_result_mocks(&server).await;
 
-    let client = ClientBuilder::new("test_user", host).port(port).build().unwrap();
+    let client = ClientBuilder::new("test_user", host)
+        .port(port)
+        .build()
+        .unwrap();
 
     let result = client
         .get_all::<Record>("SELECT a, b, c, d, f FROM t WHERE 1=0".to_string())


### PR DESCRIPTION
Recreation of #42 by @sbernauer on top of current `main` (the original PR became unmergeable after the recent merges). **Credit to [@sbernauer](https://github.com/sbernauer)** (Sebastian Bernauer) for the original work — preserved via `Co-Authored-By`.

## What

Derive `Serialize` on the result, error, stat, warning and segment model types, so query results can be **serialized** (not only deserialized). This is needed when proxying Trino traffic — e.g. [trino-lb](https://github.com/stackabletech/trino-lb) — where the models must be re-emitted.

Types now deriving `Serialize`:
- `models::result` — `QueryResult<T>`, `QueryResultData<T>`, `SpooledData`, `DataAttributes`
- `models::error` — `QueryError`, `ErrorLocation`, `FailureInfo`
- `models::stat` — `Stat`, `StageStats`
- `models::warning` — `Warning`, `Code`
- `spooling::segment` — `Segment`

## Notes
- `Column` already derived `Serialize`, so `QueryResult<T>` composes cleanly.
- Also applies `rustfmt` to `tests/get_all_empty.rs`, which was merged unformatted in #38 and was blocking the `fmt` pre-commit hook.

## Verification
- ✅ `cargo check` (default + `--features spooling`)
- ✅ `cargo clippy --all-features --tests -- -D warnings`
- ✅ pre-commit hooks (fmt / check / clippy)