### PR TITLE
ci: harden workflows and add security audit

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,0 +1,20 @@
+name: Security audit
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    # Re-run weekly so newly published advisories are caught even without a push.
+    - cron: '0 6 * * 1'
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-audit
+      - name: Run cargo audit
+        run: cargo audit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: Build and test
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:
@@ -16,39 +16,25 @@ jobs:
         os: [ubuntu-latest]
         rust: [stable, nightly]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install latest ${{ matrix.rust }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all --benches --bins --examples --tests --all-features
+        run: cargo check --all --benches --bins --examples --tests --all-features
 
       - name: Run cargo check (without dev-dependencies to catch missing feature flags)
         if: startsWith(matrix.rust, 'nightly')
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: -Z features=dev_dep
+        run: cargo check -Z features=dev_dep
 
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@v1
 
       - name: Run cargo test (unit tests with spooling feature)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --exclude trino-integration-tests --features spooling
+        run: cargo test --workspace --exclude trino-integration-tests --features spooling
 
       - name: Run integration tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --package trino-integration-tests
+        run: cargo test --package trino-integration-tests

--- a/.github/workflows/crate-release.yaml
+++ b/.github/workflows/crate-release.yaml
@@ -8,11 +8,8 @@ jobs:
     release:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v3
-        - uses: actions-rs/toolchain@v1
-          with:
-            toolchain: stable
-            override: true
+        - uses: actions/checkout@v4
+        - uses: dtolnay/rust-toolchain@stable
         - uses: katyo/publish-crates@v2
           with:
             registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,11 +17,11 @@ jobs:
 
     - name: Set up Rust
       id: rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
+        components: rustfmt, clippy
 
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v5
     - name: Run pre-commit
       uses: pre-commit/action@v3.0.1
       env:


### PR DESCRIPTION
## Why
The CI relied on the **archived / unmaintained `actions-rs/*`** actions (deprecated Node runtime, can break at any time), and there was **no `cargo audit`** gate — so the dependency vulnerabilities fixed in #44 could silently regress.

## Changes
**Migrate off `actions-rs/*`** (`ci.yaml`, `lint.yml`, `crate-release.yaml`):
- `actions-rs/toolchain` → `dtolnay/rust-toolchain` (maintained)
- `actions-rs/cargo` → plain `run: cargo ...` steps
- `actions/checkout@v2`/`@v3` → `@v4`, `actions/setup-python@v3` → `@v5`
- `lint.yml`: install `rustfmt` + `clippy` components explicitly (needed by the pre-commit hooks)

**Fix `ci.yaml` push trigger** — it listened on `master`, but the default branch is `main`, so the push trigger never fired. Now runs on push to `main` **and** PRs.

**New `audit.yaml`** — runs `cargo audit` on push, PR, and a weekly cron (to catch newly published advisories). Uses `taiki-e/install-action` for a fast prebuilt `cargo-audit`. Currently green (0 vulnerabilities; the only remaining item is the `paste` *unmaintained* warning, which does not fail the job).

## Verification
- ✅ All workflow YAML parses cleanly.
- ✅ `cargo audit` exits 0 locally on the current tree.