### PR TITLE
fix: bump trino-rust-client-macros to 0.7.2 (unblock 0.10.0 publish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 ### Changed
 - Refreshed direct dependency versions (`backon`, `chrono`, `futures`, `http`, `log`, `regex`, `reqwest`, `serde_json`, `tokio`, `tracing-subscriber`, `uuid`) [#44](https://github.com/nudibranches-tech/trino-rust-client/pull/44)
 - Replaced the unmaintained `dotenv` dev-dependency with the maintained `dotenvy` [#44](https://github.com/nudibranches-tech/trino-rust-client/pull/44)
+- Bumped `trino-rust-client-macros` to 0.7.2 (adds `#[trino(rename = "...")]` support)
 
 ### Removed
 - **Breaking:** Removed the unused `Trino` feature [#40](https://github.com/nudibranches-tech/trino-rust-client/pull/40)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ serde_json = "1.0.150"
 thiserror = "2.0.18"
 tokio = {version = "1.53", features = ["full"]}
 tracing-subscriber = {version = "0.3.23", default-features = false, features = ["fmt", "env-filter"]}
-trino-rust-client-macros = {version = "0.7.1", path = "trino-rust-client-macros"}
+trino-rust-client-macros = {version = "0.7.2", path = "trino-rust-client-macros"}
 url = "2.5.8"
 uuid = {version = "1.24.0", features = ["serde", "v4"]}
 zstd = "0.13"

--- a/trino-rust-client-macros/Cargo.toml
+++ b/trino-rust-client-macros/Cargo.toml
@@ -17,4 +17,4 @@ keywords = ["trino"]
 license = {workspace = true}
 name = "trino-rust-client-macros"
 repository = {workspace = true}
-version = "0.7.1"
+version = "0.7.2"


### PR DESCRIPTION
## Why
The 0.10.0 release **failed to publish** to crates.io:

```
It seems package 'trino-rust-client-macros' modified since '0.7.1' so new version should be published
Error: Found 1 packages with consistency errors: trino-rust-client-macros
```

#43 added a `structmeta` dependency and the `#[trino(rename = "...")]` attribute to `trino-rust-client-macros`, but its version stayed at **0.7.1** — already published on crates.io. `katyo/publish-crates` (rightly) refuses to republish an existing version with different content.

## Fix
- Bump `trino-rust-client-macros` `0.7.1` → `0.7.2`
- Align the workspace dependency to `0.7.2`
- CHANGELOG note under 0.10.0

After merge, the `0.10.0` tag will be re-pointed to include this fix to re-trigger the publish workflow.

Not related to the CI-hardening migration (#46) — the toolchain/publish steps ran fine; this is purely a version-consistency error.