### PR TITLE
feat: add Client::stream for lazy row streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## [Unreleased]
 ### Added
-- `Client::stream` — lazily stream query rows page by page as a `futures::Stream`, without buffering the whole result set in memory (Direct and Spooled protocols)
+- `Client::stream` — lazily stream query rows page by page without buffering the whole result set in memory (Direct and Spooled protocols). Returns a `RowStream` that resolves the result schema up front (`RowStream::columns`) and implements `futures::Stream`
 
 ## [0.10.0] - 2026-07-18
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## [Unreleased]
 ### Added
-- `Client::stream` — lazily stream query rows page by page without buffering the whole result set in memory (Direct and Spooled protocols). Returns a `RowStream` that resolves the result schema up front (`RowStream::columns`) and implements `futures::Stream`
+- `Client::stream` — lazily stream query rows page by page without buffering the whole result set in memory (Direct and Spooled protocols). Returns a `RowStream` that resolves the result columns up front (`RowStream::columns() -> &[Column]`), implements `futures::Stream`, is `Send`/`Unpin`, and best-effort cancels the query on the coordinator if dropped before completion
 
 ## [0.10.0] - 2026-07-18
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://book.async.rs/overview/stability-guarantees.html).
 
 ## [Unreleased]
+### Added
+- `Client::stream` — lazily stream query rows page by page as a `futures::Stream`, without buffering the whole result set in memory (Direct and Spooled protocols)
 
 ## [0.10.0] - 2026-07-18
 ### Security

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [dependencies]
+async-stream = {workspace = true}
 backon = {workspace = true}
 base64 = {workspace = true, optional = true}
 bigdecimal = {workspace = true}
@@ -64,6 +65,7 @@ required-features = ["spooling"]
 members = [".", "trino-rust-client-macros", "integration_tests"]
 
 [workspace.dependencies]
+async-stream = "0.3.6"
 backon = "1.6.0"
 base64 = "0.22"
 bigdecimal = "0.4.10"

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -1,0 +1,45 @@
+use std::env::var;
+
+use dotenvy::dotenv;
+use futures::StreamExt;
+use trino_rust_client::{ClientBuilder, Row};
+
+/// Stream a query's rows lazily instead of buffering the whole result set.
+///
+/// Run with the same environment variables as the other examples
+/// (USER, HOST, PORT, CATALOG, SQL), e.g. via a `.env` file.
+#[tokio::main]
+async fn main() {
+    dotenv().ok();
+
+    let user = var("USER").unwrap();
+    let host = var("HOST").unwrap();
+    let port = var("PORT").unwrap().parse().unwrap();
+    let catalog = var("CATALOG").unwrap();
+    let sql = var("SQL").unwrap();
+
+    let cli = ClientBuilder::new(user, host)
+        .port(port)
+        .catalog(catalog)
+        .build()
+        .unwrap();
+
+    let stream = cli.stream::<Row>(sql);
+    tokio::pin!(stream);
+
+    let mut count = 0usize;
+    while let Some(row) = stream.next().await {
+        match row {
+            Ok(row) => {
+                count += 1;
+                println!("{:?}", row);
+            }
+            Err(e) => {
+                eprintln!("stream error: {e}");
+                break;
+            }
+        }
+    }
+
+    println!("streamed {count} rows");
+}

--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -24,8 +24,8 @@ async fn main() {
         .build()
         .unwrap();
 
-    let stream = cli.stream::<Row>(sql);
-    tokio::pin!(stream);
+    let mut stream = cli.stream::<Row>(sql).await.unwrap();
+    println!("columns: {:?}", stream.columns());
 
     let mut count = 0usize;
     while let Some(row) = stream.next().await {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,6 @@
 use std::collections::{HashMap, HashSet};
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use backon::ExponentialBuilder;
 use backon::Retryable;
@@ -17,6 +19,9 @@ use crate::build_dataset;
 use crate::error::TrinoRetryResult;
 use crate::error::{Error, Result};
 use crate::header::*;
+#[cfg(feature = "spooling")]
+use crate::models::Column;
+use crate::models::QueryError;
 use crate::models::QueryResultData;
 #[cfg(feature = "spooling")]
 use crate::models::SpooledData;
@@ -28,6 +33,7 @@ use crate::spooling::decompress_segment_bytes;
 use crate::spooling::{SegmentFetcher, SpoolingEncoding};
 use crate::ssl::Ssl;
 use crate::transaction::TransactionId;
+use crate::types::TrinoTy;
 use crate::{DataSet, QueryResult, Row, Trino};
 
 // TODO:
@@ -457,7 +463,7 @@ fn need_retry(e: &Error) -> bool {
 }
 
 /// Map a per-page Trino error (carried in `QueryResult::error`) to a client [`Error`].
-fn map_page_error(error: crate::models::QueryError) -> Error {
+fn map_page_error(error: QueryError) -> Error {
     // error_code 4 is Trino's PERMISSION_DENIED
     if error.error_code == 4 {
         Error::Forbidden {
@@ -471,17 +477,61 @@ fn map_page_error(error: crate::models::QueryError) -> Error {
     }
 }
 
+/// A lazy stream of query rows, with the result schema resolved up front.
+///
+/// Created by [`Client::stream`]. The result column schema is available
+/// immediately via [`RowStream::columns`]; rows are then produced lazily,
+/// page by page, by the [`Stream`] implementation — the whole result set is
+/// never buffered in memory.
+///
+/// `RowStream` is [`Unpin`], so it can be polled directly (e.g. with
+/// [`StreamExt::next`](futures::StreamExt::next)) without `pin!`.
+///
+/// # Cancellation
+/// Dropping a `RowStream` before it is exhausted stops the client from
+/// fetching further pages, but does **not** cancel the query on the Trino
+/// coordinator; the query lives on until it completes or the server times it
+/// out. Call [`Client::cancel`] with the query id if you need to release
+/// server resources on early termination.
+pub struct RowStream<'a, T> {
+    columns: Vec<(String, TrinoTy)>,
+    inner: Pin<Box<dyn Stream<Item = Result<T>> + 'a>>,
+}
+
+impl<T> RowStream<'_, T> {
+    /// The result schema (column name and Trino type), resolved before the
+    /// first row is produced.
+    pub fn columns(&self) -> &[(String, TrinoTy)] {
+        &self.columns
+    }
+}
+
+impl<T> Stream for RowStream<'_, T> {
+    type Item = Result<T>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.get_mut().inner.as_mut().poll_next(cx)
+    }
+}
+
 impl Client {
     /// Execute `sql` and stream the resulting rows lazily, page by page, without
     /// buffering the whole result set in memory.
     ///
-    /// Trino returns results as a chain of pages linked by `nextUri`; this method
-    /// follows that chain on demand and yields each row as it is decoded. Prefer it
-    /// over [`Client::get_all`] for large result sets.
+    /// Trino returns results as a chain of pages linked by `nextUri`. This method
+    /// first drives the query far enough to resolve the result schema (so
+    /// [`RowStream::columns`] is available up front), then hands back a
+    /// [`RowStream`] that follows the remaining pages on demand, yielding each
+    /// row as it is decoded. Prefer it over [`Client::get_all`] for large result
+    /// sets.
     ///
     /// Both the Direct and (with the `spooling` feature) Spooled protocols are
-    /// supported. With spooling, rows are still materialized one segment at a time
-    /// rather than for the entire query, keeping peak memory bounded.
+    /// supported. With spooling, rows are still materialized one segment at a
+    /// time rather than for the entire query, keeping peak memory bounded.
+    ///
+    /// Unlike [`Client::get_all`], this does not reject a query that mixes the
+    /// Direct and Spooled protocols across pages; each page is decoded according
+    /// to its own protocol.
     ///
     /// The returned stream borrows `self`, so it must not outlive the [`Client`].
     ///
@@ -492,8 +542,8 @@ impl Client {
     /// use futures::StreamExt;
     ///
     /// let client = ClientBuilder::new("user", "localhost").port(8080).build()?;
-    /// let mut rows = client.stream::<Row>("SELECT 1");
-    /// tokio::pin!(rows);
+    /// let mut rows = client.stream::<Row>("SELECT 1").await?;
+    /// println!("columns: {:?}", rows.columns());
     /// while let Some(row) = rows.next().await {
     ///     let row = row?;
     ///     // use row
@@ -501,18 +551,46 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn stream<'a, T>(&'a self, sql: impl Into<String>) -> impl Stream<Item = Result<T>> + 'a
+    pub async fn stream<'a, T>(&'a self, sql: impl Into<String>) -> Result<RowStream<'a, T>>
     where
         T: Trino + 'static,
         for<'de> T: serde::Deserialize<'de>,
     {
         let sql = sql.into();
-        async_stream::try_stream! {
-            let mut res = self.get_retry::<T>(sql).await?;
-            // Column metadata is only guaranteed on the first page that carries it;
-            // remember it so later spooled pages can be decoded.
+
+        // Prime the query until the schema is known: follow pages until one
+        // carries `columns` (or the query finishes without any). Errors on these
+        // early pages are surfaced eagerly.
+        let mut res = self.get_retry::<T>(sql).await?;
+        loop {
+            if let Some(error) = res.error.take() {
+                return Err(map_page_error(error));
+            }
+            if res.columns.is_some() || res.data.is_some() {
+                break;
+            }
+            match res.next_uri.clone() {
+                Some(url) => res = self.get_next_retry::<T>(&url).await?,
+                None => break,
+            }
+        }
+
+        let columns = match res.columns.clone() {
+            Some(cols) => cols
+                .into_iter()
+                .map(TrinoTy::from_column)
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(|e| Error::InternalError(format!("Failed to convert columns: {}", e)))?,
+            None => Vec::new(),
+        };
+
+        let inner = async_stream::try_stream! {
+            // `res` already holds the first schema-bearing page (with its data,
+            // if any); keep decoding from there.
+            let mut res = res;
+            // Track raw columns across pages so later spooled pages can be decoded.
             #[cfg(feature = "spooling")]
-            let mut columns = res.columns.clone();
+            let mut raw_columns: Option<Vec<Column>> = res.columns.clone();
 
             loop {
                 if let Some(error) = res.error.take() {
@@ -520,8 +598,8 @@ impl Client {
                 }
 
                 #[cfg(feature = "spooling")]
-                if columns.is_none() {
-                    columns = res.columns.clone();
+                if raw_columns.is_none() {
+                    raw_columns = res.columns.clone();
                 }
 
                 if let Some(data) = res.data.take() {
@@ -533,7 +611,7 @@ impl Client {
                         }
                         #[cfg(feature = "spooling")]
                         QueryResultData::Spooled(spooled) => {
-                            let cols = columns.clone().or_else(|| res.columns.clone());
+                            let cols = raw_columns.clone().or_else(|| res.columns.clone());
                             let ds = self.fetch_spooled_data::<T>(spooled, cols).await?;
                             for row in ds.into_vec() {
                                 yield row;
@@ -549,14 +627,19 @@ impl Client {
                     }
                 }
 
-                match res.next_uri.clone() {
+                match res.next_uri.take() {
                     Some(url) => {
                         res = self.get_next_retry::<T>(&url).await?;
                     }
                     None => break,
                 }
             }
-        }
+        };
+
+        Ok(RowStream {
+            columns,
+            inner: Box::pin(inner),
+        })
     }
 
     pub async fn get_all<T>(&self, sql: String) -> Result<DataSet<T>>

--- a/src/client.rs
+++ b/src/client.rs
@@ -485,7 +485,8 @@ fn map_page_error(error: QueryError) -> Error {
 /// never buffered in memory.
 ///
 /// `RowStream` is [`Unpin`], so it can be polled directly (e.g. with
-/// [`StreamExt::next`](futures::StreamExt::next)) without `pin!`.
+/// [`StreamExt::next`](futures::StreamExt::next)) without `pin!`, and [`Send`],
+/// so it can be held across `.await` inside a spawned task.
 ///
 /// # Cancellation
 /// Dropping a `RowStream` before it is exhausted stops the client from
@@ -495,7 +496,7 @@ fn map_page_error(error: QueryError) -> Error {
 /// server resources on early termination.
 pub struct RowStream<'a, T> {
     columns: Vec<(String, TrinoTy)>,
-    inner: Pin<Box<dyn Stream<Item = Result<T>> + 'a>>,
+    inner: Pin<Box<dyn Stream<Item = Result<T>> + Send + 'a>>,
 }
 
 impl<T> RowStream<'_, T> {
@@ -553,7 +554,7 @@ impl Client {
     /// ```
     pub async fn stream<'a, T>(&'a self, sql: impl Into<String>) -> Result<RowStream<'a, T>>
     where
-        T: Trino + 'static,
+        T: Trino + Send + 'static,
         for<'de> T: serde::Deserialize<'de>,
     {
         let sql = sql.into();

--- a/src/client.rs
+++ b/src/client.rs
@@ -19,7 +19,6 @@ use crate::build_dataset;
 use crate::error::TrinoRetryResult;
 use crate::error::{Error, Result};
 use crate::header::*;
-#[cfg(feature = "spooling")]
 use crate::models::Column;
 use crate::models::QueryError;
 use crate::models::QueryResultData;
@@ -33,7 +32,6 @@ use crate::spooling::decompress_segment_bytes;
 use crate::spooling::{SegmentFetcher, SpoolingEncoding};
 use crate::ssl::Ssl;
 use crate::transaction::TransactionId;
-use crate::types::TrinoTy;
 use crate::{DataSet, QueryResult, Row, Trino};
 
 // TODO:
@@ -477,32 +475,42 @@ fn map_page_error(error: QueryError) -> Error {
     }
 }
 
-/// A lazy stream of query rows, with the result schema resolved up front.
+/// Everything needed to fire a best-effort query cancellation from
+/// [`RowStream`]'s `Drop`, without borrowing the [`Client`].
+struct CancelOnDrop {
+    client: reqwest::Client,
+    url: String,
+    auth: Option<Auth>,
+}
+
+/// A lazy stream of query rows, with the result columns resolved up front.
 ///
-/// Created by [`Client::stream`]. The result column schema is available
-/// immediately via [`RowStream::columns`]; rows are then produced lazily,
-/// page by page, by the [`Stream`] implementation — the whole result set is
-/// never buffered in memory.
+/// Created by [`Client::stream`]. The result columns are available immediately
+/// via [`RowStream::columns`]; rows are then produced lazily, page by page, by
+/// the [`Stream`] implementation — the whole result set is never buffered in
+/// memory.
 ///
 /// `RowStream` is [`Unpin`], so it can be polled directly (e.g. with
 /// [`StreamExt::next`](futures::StreamExt::next)) without `pin!`, and [`Send`],
 /// so it can be held across `.await` inside a spawned task.
 ///
 /// # Cancellation
-/// Dropping a `RowStream` before it is exhausted stops the client from
-/// fetching further pages, but does **not** cancel the query on the Trino
-/// coordinator; the query lives on until it completes or the server times it
-/// out. Call [`Client::cancel`] with the query id if you need to release
-/// server resources on early termination.
+/// Dropping a `RowStream` before it is exhausted best-effort cancels the query
+/// on the Trino coordinator (a fire-and-forget `DELETE`), so early termination
+/// (`take`, `break`, an error, a dropped task) does not leave the query running
+/// server-side and holding coordinator resources. Cancellation is skipped once
+/// the query has finished normally, and requires a Tokio runtime to be active
+/// at drop time.
 pub struct RowStream<'a, T> {
-    columns: Vec<(String, TrinoTy)>,
+    columns: Vec<Column>,
+    cancel: Option<CancelOnDrop>,
     inner: Pin<Box<dyn Stream<Item = Result<T>> + Send + 'a>>,
 }
 
 impl<T> RowStream<'_, T> {
-    /// The result schema (column name and Trino type), resolved before the
-    /// first row is produced.
-    pub fn columns(&self) -> &[(String, TrinoTy)] {
+    /// The result columns (name, Trino type name and full type signature),
+    /// resolved before the first row is produced.
+    pub fn columns(&self) -> &[Column] {
         &self.columns
     }
 }
@@ -511,7 +519,34 @@ impl<T> Stream for RowStream<'_, T> {
     type Item = Result<T>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.get_mut().inner.as_mut().poll_next(cx)
+        let me = self.get_mut();
+        let polled = me.inner.as_mut().poll_next(cx);
+        if let Poll::Ready(None) = polled {
+            // The query finished normally — there is nothing to cancel.
+            me.cancel = None;
+        }
+        polled
+    }
+}
+
+impl<T> Drop for RowStream<'_, T> {
+    fn drop(&mut self) {
+        let Some(cancel) = self.cancel.take() else {
+            return;
+        };
+        // Fire-and-forget; only possible from within a running Tokio runtime.
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                let mut req = cancel.client.delete(&cancel.url);
+                if let Some(auth) = &cancel.auth {
+                    req = match auth {
+                        Auth::Basic(u, p) => req.basic_auth(u, p.as_ref()),
+                        Auth::Jwt(t) => req.bearer_auth(t),
+                    };
+                }
+                let _ = req.send().await;
+            });
+        }
     }
 }
 
@@ -576,14 +611,15 @@ impl Client {
             }
         }
 
-        let columns = match res.columns.clone() {
-            Some(cols) => cols
-                .into_iter()
-                .map(TrinoTy::from_column)
-                .collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(|e| Error::InternalError(format!("Failed to convert columns: {}", e)))?,
-            None => Vec::new(),
-        };
+        let columns = res.columns.clone().unwrap_or_default();
+
+        // Capture what is needed to cancel the query on early drop, without
+        // borrowing `self` (so the cancel can be spawned as a 'static task).
+        let cancel = Some(CancelOnDrop {
+            client: self.client.clone(),
+            url: format!("{}v1/query/{}", self.url, res.id),
+            auth: self.auth.clone(),
+        });
 
         let inner = async_stream::try_stream! {
             // `res` already holds the first schema-bearing page (with its data,
@@ -639,6 +675,7 @@ impl Client {
 
         Ok(RowStream {
             columns,
+            cancel,
             inner: Box::pin(inner),
         })
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use backon::ExponentialBuilder;
 use backon::Retryable;
+use futures::Stream;
 use http::header::{ACCEPT_ENCODING, USER_AGENT};
 use http::StatusCode;
 use iterable::*;
@@ -455,7 +456,109 @@ fn need_retry(e: &Error) -> bool {
     }
 }
 
+/// Map a per-page Trino error (carried in `QueryResult::error`) to a client [`Error`].
+fn map_page_error(error: crate::models::QueryError) -> Error {
+    // error_code 4 is Trino's PERMISSION_DENIED
+    if error.error_code == 4 {
+        Error::Forbidden {
+            message: error.message,
+        }
+    } else {
+        Error::InternalError(format!(
+            "Query failed with {} (error code {}): {}",
+            error.error_name, error.error_code, error.message
+        ))
+    }
+}
+
 impl Client {
+    /// Execute `sql` and stream the resulting rows lazily, page by page, without
+    /// buffering the whole result set in memory.
+    ///
+    /// Trino returns results as a chain of pages linked by `nextUri`; this method
+    /// follows that chain on demand and yields each row as it is decoded. Prefer it
+    /// over [`Client::get_all`] for large result sets.
+    ///
+    /// Both the Direct and (with the `spooling` feature) Spooled protocols are
+    /// supported. With spooling, rows are still materialized one segment at a time
+    /// rather than for the entire query, keeping peak memory bounded.
+    ///
+    /// The returned stream borrows `self`, so it must not outlive the [`Client`].
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use trino_rust_client::{client::ClientBuilder, Row};
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// use futures::StreamExt;
+    ///
+    /// let client = ClientBuilder::new("user", "localhost").port(8080).build()?;
+    /// let mut rows = client.stream::<Row>("SELECT 1");
+    /// tokio::pin!(rows);
+    /// while let Some(row) = rows.next().await {
+    ///     let row = row?;
+    ///     // use row
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn stream<'a, T>(&'a self, sql: impl Into<String>) -> impl Stream<Item = Result<T>> + 'a
+    where
+        T: Trino + 'static,
+        for<'de> T: serde::Deserialize<'de>,
+    {
+        let sql = sql.into();
+        async_stream::try_stream! {
+            let mut res = self.get_retry::<T>(sql).await?;
+            // Column metadata is only guaranteed on the first page that carries it;
+            // remember it so later spooled pages can be decoded.
+            #[cfg(feature = "spooling")]
+            let mut columns = res.columns.clone();
+
+            loop {
+                if let Some(error) = res.error.take() {
+                    Err(map_page_error(error))?;
+                }
+
+                #[cfg(feature = "spooling")]
+                if columns.is_none() {
+                    columns = res.columns.clone();
+                }
+
+                if let Some(data) = res.data.take() {
+                    match data {
+                        QueryResultData::Direct(rows) => {
+                            for row in rows {
+                                yield row;
+                            }
+                        }
+                        #[cfg(feature = "spooling")]
+                        QueryResultData::Spooled(spooled) => {
+                            let cols = columns.clone().or_else(|| res.columns.clone());
+                            let ds = self.fetch_spooled_data::<T>(spooled, cols).await?;
+                            for row in ds.into_vec() {
+                                yield row;
+                            }
+                        }
+                        #[cfg(not(feature = "spooling"))]
+                        QueryResultData::Spooled(_) => {
+                            Err(Error::InternalError(
+                                "Server sent spooled data but 'spooling' feature is not enabled. \
+                                 Add features = [\"spooling\"] to your trino-rust-client dependency in Cargo.toml.".to_string(),
+                            ))?;
+                        }
+                    }
+                }
+
+                match res.next_uri.clone() {
+                    Some(url) => {
+                        res = self.get_next_retry::<T>(&url).await?;
+                    }
+                    None => break,
+                }
+            }
+        }
+    }
+
     pub async fn get_all<T>(&self, sql: String) -> Result<DataSet<T>>
     where
         T: Trino + 'static,

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -104,6 +104,33 @@ async fn test_stream_yields_rows_across_pages() {
     assert_eq!(rows.len(), 3, "expected 3 rows streamed across 3 pages");
 }
 
+// A RowStream must be `Send` so it can be held across `.await` inside a
+// spawned task (a very common pattern in async services). This test would fail
+// to compile if the inner boxed stream were not `Send`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_stream_is_send_and_spawnable() {
+    let (server, host, port) = make_mock_server().await;
+    mount_paged_result(&server).await;
+
+    let count = tokio::spawn(async move {
+        let cli = client(host, port);
+        let mut stream = cli.stream::<Row>("SELECT * FROM t").await.unwrap();
+        let mut n = 0usize;
+        while let Some(item) = stream.next().await {
+            item.unwrap();
+            n += 1;
+        }
+        n
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(
+        count, 3,
+        "streaming inside a spawned task should yield 3 rows"
+    );
+}
+
 #[tokio::test]
 async fn test_stream_empty_result_set() {
     let (server, host, port) = make_mock_server().await;

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -20,66 +20,66 @@ async fn make_mock_server() -> (MockServer, String, u16) {
     (server, host.to_string(), port)
 }
 
-/// Mount a three-page lifecycle:
-///   POST /v1/statement -> QUEUED, no data, nextUri -> /1
-///   GET  /1            -> 2 rows, nextUri -> /2
-///   GET  /2            -> 1 row, no nextUri (query finished)
-/// Total: 3 rows streamed across 3 pages.
+fn client(host: String, port: u16) -> trino_rust_client::client::Client {
+    ClientBuilder::new("test_user", host)
+        .port(port)
+        .build()
+        .unwrap()
+}
+
+async fn mount(server: &MockServer, verb: &str, p: &str, body: Value) {
+    let m = if verb == "POST" {
+        Mock::given(method("POST")).and(path("/v1/statement".to_string()))
+    } else {
+        Mock::given(method("GET")).and(path(p.to_string()))
+    };
+    m.respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
+
+/// Three-page lifecycle: QUEUED -> 2 rows -> 1 row (finished). Total 3 rows.
 async fn mount_paged_result(server: &MockServer) {
     let uri = server.uri();
     let finished = read_fixture("query_result_finished");
     let columns = finished["columns"].clone();
     let row = finished["data"][0].clone();
-    // Reuse a full stats block from the fixture so `Stat` deserializes.
     let stats = finished["stats"].clone();
 
-    let page1 = json!({
-        "id": "test_stream_00001",
-        "infoUri": format!("{uri}/ui/query.html?test_stream_00001"),
-        "nextUri": format!("{uri}/v1/statement/test_stream_00001/1"),
-        "stats": stats.clone(),
-        "warnings": []
-    });
-
-    let page2 = json!({
-        "id": "test_stream_00001",
-        "infoUri": format!("{uri}/ui/query.html?test_stream_00001"),
-        "nextUri": format!("{uri}/v1/statement/test_stream_00001/2"),
-        "columns": columns,
-        "data": [row.clone(), row.clone()],
-        "stats": stats.clone(),
-        "warnings": []
-    });
-
-    let page3 = json!({
-        "id": "test_stream_00001",
-        "infoUri": format!("{uri}/ui/query.html?test_stream_00001"),
-        "columns": finished["columns"].clone(),
-        "data": [row],
-        "stats": stats,
-        "warnings": []
-    });
-
-    Mock::given(method("POST"))
-        .and(path("/v1/statement"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(page1))
-        .expect(1)
-        .mount(server)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/v1/statement/test_stream_00001/1"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(page2))
-        .expect(1)
-        .mount(server)
-        .await;
-
-    Mock::given(method("GET"))
-        .and(path("/v1/statement/test_stream_00001/2"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(page3))
-        .expect(1)
-        .mount(server)
-        .await;
+    mount(
+        server,
+        "POST",
+        "",
+        json!({
+            "id": "q", "infoUri": format!("{uri}/ui"),
+            "nextUri": format!("{uri}/v1/statement/q/1"),
+            "stats": stats.clone(), "warnings": []
+        }),
+    )
+    .await;
+    mount(
+        server,
+        "GET",
+        "/v1/statement/q/1",
+        json!({
+            "id": "q", "infoUri": format!("{uri}/ui"),
+            "nextUri": format!("{uri}/v1/statement/q/2"),
+            "columns": columns, "data": [row.clone(), row.clone()],
+            "stats": stats.clone(), "warnings": []
+        }),
+    )
+    .await;
+    mount(
+        server,
+        "GET",
+        "/v1/statement/q/2",
+        json!({
+            "id": "q", "infoUri": format!("{uri}/ui"),
+            "columns": finished["columns"].clone(), "data": [row],
+            "stats": stats, "warnings": []
+        }),
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -87,65 +87,127 @@ async fn test_stream_yields_rows_across_pages() {
     let (server, host, port) = make_mock_server().await;
     mount_paged_result(&server).await;
 
-    let client = ClientBuilder::new("test_user", host)
-        .port(port)
-        .build()
-        .unwrap();
+    let cli = client(host, port);
+    let mut stream = cli
+        .stream::<Row>("SELECT * FROM t")
+        .await
+        .expect("stream creation should resolve the schema");
 
-    let stream = client.stream::<Row>("SELECT * FROM t".to_string());
-    tokio::pin!(stream);
+    // Schema is available up front, before any row is pulled.
+    assert_eq!(stream.columns().len(), 6, "schema resolved up front");
+    assert_eq!(stream.columns()[0].0, "a");
 
     let mut rows = Vec::new();
     while let Some(item) = stream.next().await {
         rows.push(item.expect("stream item should be Ok"));
     }
-
-    // 2 rows from page 2 + 1 row from page 3, without ever buffering the whole set.
     assert_eq!(rows.len(), 3, "expected 3 rows streamed across 3 pages");
-
-    server.verify().await;
 }
 
 #[tokio::test]
-async fn test_stream_surfaces_query_error() {
+async fn test_stream_empty_result_set() {
     let (server, host, port) = make_mock_server().await;
     let uri = server.uri();
+    let finished = read_fixture("query_result_finished");
+    let stats = finished["stats"].clone();
 
-    let page1 = json!({
-        "id": "test_stream_err",
-        "infoUri": format!("{uri}/ui/query.html?test_stream_err"),
-        "nextUri": format!("{uri}/v1/statement/test_stream_err/1"),
-        "stats": read_fixture("query_result_finished")["stats"].clone(),
-        "warnings": []
-    });
-    // Error page carried inside a 200 response (Trino reports query errors this way).
-    let err_page = read_fixture("query_result_failed");
+    mount(
+        &server,
+        "POST",
+        "",
+        json!({
+            "id": "e", "infoUri": format!("{uri}/ui"),
+            "nextUri": format!("{uri}/v1/statement/e/1"),
+            "stats": stats.clone(), "warnings": []
+        }),
+    )
+    .await;
+    // Finished page with schema but zero rows and no nextUri.
+    mount(
+        &server,
+        "GET",
+        "/v1/statement/e/1",
+        json!({
+            "id": "e", "infoUri": format!("{uri}/ui"),
+            "columns": finished["columns"].clone(),
+            "stats": stats, "warnings": []
+        }),
+    )
+    .await;
 
-    Mock::given(method("POST"))
-        .and(path("/v1/statement"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(page1))
-        .mount(&server)
-        .await;
-    Mock::given(method("GET"))
-        .and(path("/v1/statement/test_stream_err/1"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(err_page))
-        .mount(&server)
-        .await;
+    let cli = client(host, port);
+    let mut stream = cli
+        .stream::<Row>("SELECT * FROM t WHERE 1=0")
+        .await
+        .expect("empty result must still resolve a schema");
 
-    let client = ClientBuilder::new("test_user", host)
-        .port(port)
-        .build()
-        .unwrap();
+    assert_eq!(stream.columns().len(), 6, "schema preserved for zero rows");
+    let mut count = 0;
+    while let Some(item) = stream.next().await {
+        item.expect("no error expected");
+        count += 1;
+    }
+    assert_eq!(count, 0, "no rows for an empty result set");
+}
 
-    let stream = client.stream::<Row>("SELECT * FROM t".to_string());
-    tokio::pin!(stream);
+#[tokio::test]
+async fn test_stream_surfaces_mid_stream_error() {
+    let (server, host, port) = make_mock_server().await;
+    let uri = server.uri();
+    let finished = read_fixture("query_result_finished");
+    let stats = finished["stats"].clone();
+    let row = finished["data"][0].clone();
 
+    mount(
+        &server,
+        "POST",
+        "",
+        json!({
+            "id": "x", "infoUri": format!("{uri}/ui"),
+            "nextUri": format!("{uri}/v1/statement/x/1"),
+            "stats": stats.clone(), "warnings": []
+        }),
+    )
+    .await;
+    // Page with schema + 2 rows, then a link to a failing page.
+    mount(
+        &server,
+        "GET",
+        "/v1/statement/x/1",
+        json!({
+            "id": "x", "infoUri": format!("{uri}/ui"),
+            "nextUri": format!("{uri}/v1/statement/x/2"),
+            "columns": finished["columns"].clone(), "data": [row.clone(), row],
+            "stats": stats, "warnings": []
+        }),
+    )
+    .await;
+    // Error page (carried inside a 200, as Trino does).
+    mount(
+        &server,
+        "GET",
+        "/v1/statement/x/2",
+        read_fixture("query_result_failed"),
+    )
+    .await;
+
+    let cli = client(host, port);
+    let mut stream = cli
+        .stream::<Row>("SELECT * FROM t")
+        .await
+        .expect("schema resolves before the failing page");
+
+    let mut oks = 0;
     let mut saw_error = false;
     while let Some(item) = stream.next().await {
-        if item.is_err() {
-            saw_error = true;
-            break;
+        match item {
+            Ok(_) => oks += 1,
+            Err(_) => {
+                saw_error = true;
+                break;
+            }
         }
     }
-    assert!(saw_error, "a query error page must surface as an Err item");
+    assert_eq!(oks, 2, "two rows should stream before the error");
+    assert!(saw_error, "the failing page must surface as an Err item");
 }

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -95,7 +95,7 @@ async fn test_stream_yields_rows_across_pages() {
 
     // Schema is available up front, before any row is pulled.
     assert_eq!(stream.columns().len(), 6, "schema resolved up front");
-    assert_eq!(stream.columns()[0].0, "a");
+    assert_eq!(stream.columns()[0].name, "a");
 
     let mut rows = Vec::new();
     while let Some(item) = stream.next().await {
@@ -313,4 +313,70 @@ async fn test_stream_surfaces_mid_stream_error() {
     }
     assert_eq!(oks, 2, "two rows should stream before the error");
     assert!(saw_error, "the failing page must surface as an Err item");
+}
+
+// Dropping a RowStream before the query finishes must best-effort cancel the
+// query on the coordinator (fire-and-forget DELETE /v1/query/{id}).
+#[tokio::test]
+async fn test_stream_cancels_query_on_early_drop() {
+    use std::time::Duration;
+
+    let (server, host, port) = make_mock_server().await;
+    let uri = server.uri();
+    let finished = read_fixture("query_result_finished");
+    let stats = finished["stats"].clone();
+    let row = finished["data"][0].clone();
+
+    mount(
+        &server,
+        "POST",
+        "",
+        json!({
+            "id": "c", "infoUri": format!("{uri}/ui"),
+            "nextUri": format!("{uri}/v1/statement/c/1"),
+            "stats": stats.clone(), "warnings": []
+        }),
+    )
+    .await;
+    // Schema + 2 rows + a link to a further page that we never fetch (we drop first).
+    mount(
+        &server,
+        "GET",
+        "/v1/statement/c/1",
+        json!({
+            "id": "c", "infoUri": format!("{uri}/ui"),
+            "nextUri": format!("{uri}/v1/statement/c/2"),
+            "columns": finished["columns"].clone(), "data": [row.clone(), row],
+            "stats": stats, "warnings": []
+        }),
+    )
+    .await;
+    // Cancellation endpoint.
+    Mock::given(method("DELETE"))
+        .and(path("/v1/query/c"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let cli = client(host, port);
+    {
+        let mut stream = cli.stream::<Row>("SELECT * FROM t").await.unwrap();
+        // Pull a single row, leaving the query unfinished, then drop the stream.
+        let _first = stream.next().await.expect("one row").expect("ok");
+    } // <- RowStream dropped here, mid-stream
+
+    // The cancel runs on a spawned fire-and-forget task; poll the mock for it.
+    let mut cancelled = false;
+    for _ in 0..40 {
+        let reqs = server.received_requests().await.unwrap_or_default();
+        if reqs.iter().any(|r| r.url.path() == "/v1/query/c") {
+            cancelled = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(
+        cancelled,
+        "dropping an unfinished RowStream should cancel the query"
+    );
 }

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -206,7 +206,8 @@ async fn test_stream_spooled_inline_segments() {
         }),
     )
     .await;
-    // Spooled page with two inline JSON segments: [{id:1,name:"alice"}], [{id:2,name:"bob"}]
+    // Spooled page with two inline JSON segments in Trino's native row-array
+    // format: [[1,"alice"]] and [[2,"bob"]] (base64-encoded).
     mount(
         &server,
         "GET",

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -177,6 +177,81 @@ async fn test_stream_empty_result_set() {
     assert_eq!(count, 0, "no rows for an empty result set");
 }
 
+// The streaming + spooling combination is the highest-value path (large
+// results). Exercise it end-to-end with inline segments (no object storage
+// needed): the stream must resolve the schema and decode spooled rows.
+#[cfg(feature = "spooling")]
+#[tokio::test]
+async fn test_stream_spooled_inline_segments() {
+    use trino_rust_client::Trino;
+
+    #[derive(Trino, Debug, serde::Deserialize, serde::Serialize)]
+    struct SpooledRecord {
+        id: i64,
+        name: String,
+    }
+
+    let (server, host, port) = make_mock_server().await;
+    let uri = server.uri();
+    let stats = read_fixture("query_result_finished")["stats"].clone();
+
+    mount(
+        &server,
+        "POST",
+        "",
+        json!({
+            "id": "s", "infoUri": format!("{uri}/ui"),
+            "nextUri": format!("{uri}/v1/statement/s/1"),
+            "stats": stats.clone(), "warnings": []
+        }),
+    )
+    .await;
+    // Spooled page with two inline JSON segments: [{id:1,name:"alice"}], [{id:2,name:"bob"}]
+    mount(
+        &server,
+        "GET",
+        "/v1/statement/s/1",
+        json!({
+            "id": "s", "infoUri": format!("{uri}/ui"),
+            "columns": [
+                { "name": "id", "type": "bigint", "typeSignature": { "rawType": "bigint", "arguments": [] } },
+                { "name": "name", "type": "varchar", "typeSignature": { "rawType": "varchar", "arguments": [] } }
+            ],
+            "data": {
+                "encoding": "json",
+                "segments": [
+                    { "type": "inline", "data": "W1sxLCJhbGljZSJdXQ==", "metadata": {} },
+                    { "type": "inline", "data": "W1syLCJib2IiXV0=", "metadata": {} }
+                ]
+            },
+            "stats": stats, "warnings": []
+        }),
+    )
+    .await;
+
+    let cli = client(host, port);
+    let mut stream = cli
+        .stream::<SpooledRecord>("SELECT id, name FROM t")
+        .await
+        .expect("schema resolves for the spooled result");
+
+    assert_eq!(
+        stream.columns().len(),
+        2,
+        "spooled schema resolved up front"
+    );
+
+    let mut rows = Vec::new();
+    while let Some(item) = stream.next().await {
+        rows.push(item.expect("spooled row should decode"));
+    }
+    assert_eq!(rows.len(), 2, "two spooled rows streamed");
+    assert_eq!(rows[0].id, 1);
+    assert_eq!(rows[0].name, "alice");
+    assert_eq!(rows[1].id, 2);
+    assert_eq!(rows[1].name, "bob");
+}
+
 #[tokio::test]
 async fn test_stream_surfaces_mid_stream_error() {
     let (server, host, port) = make_mock_server().await;

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -1,0 +1,151 @@
+use std::fs;
+
+use futures::StreamExt;
+use serde_json::{json, Value};
+use trino_rust_client::{client::ClientBuilder, Row};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn read_fixture(name: &str) -> Value {
+    serde_json::from_str(&fs::read_to_string(format!("tests/data/models/{}", name)).unwrap())
+        .unwrap()
+}
+
+async fn make_mock_server() -> (MockServer, String, u16) {
+    let server = MockServer::start().await;
+    let uri = server.uri();
+    let host_port = uri.trim_start_matches("http://");
+    let (host, port_str) = host_port.rsplit_once(':').unwrap();
+    let port: u16 = port_str.parse().unwrap();
+    (server, host.to_string(), port)
+}
+
+/// Mount a three-page lifecycle:
+///   POST /v1/statement -> QUEUED, no data, nextUri -> /1
+///   GET  /1            -> 2 rows, nextUri -> /2
+///   GET  /2            -> 1 row, no nextUri (query finished)
+/// Total: 3 rows streamed across 3 pages.
+async fn mount_paged_result(server: &MockServer) {
+    let uri = server.uri();
+    let finished = read_fixture("query_result_finished");
+    let columns = finished["columns"].clone();
+    let row = finished["data"][0].clone();
+    // Reuse a full stats block from the fixture so `Stat` deserializes.
+    let stats = finished["stats"].clone();
+
+    let page1 = json!({
+        "id": "test_stream_00001",
+        "infoUri": format!("{uri}/ui/query.html?test_stream_00001"),
+        "nextUri": format!("{uri}/v1/statement/test_stream_00001/1"),
+        "stats": stats.clone(),
+        "warnings": []
+    });
+
+    let page2 = json!({
+        "id": "test_stream_00001",
+        "infoUri": format!("{uri}/ui/query.html?test_stream_00001"),
+        "nextUri": format!("{uri}/v1/statement/test_stream_00001/2"),
+        "columns": columns,
+        "data": [row.clone(), row.clone()],
+        "stats": stats.clone(),
+        "warnings": []
+    });
+
+    let page3 = json!({
+        "id": "test_stream_00001",
+        "infoUri": format!("{uri}/ui/query.html?test_stream_00001"),
+        "columns": finished["columns"].clone(),
+        "data": [row],
+        "stats": stats,
+        "warnings": []
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/v1/statement"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(page1))
+        .expect(1)
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/statement/test_stream_00001/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(page2))
+        .expect(1)
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/statement/test_stream_00001/2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(page3))
+        .expect(1)
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn test_stream_yields_rows_across_pages() {
+    let (server, host, port) = make_mock_server().await;
+    mount_paged_result(&server).await;
+
+    let client = ClientBuilder::new("test_user", host)
+        .port(port)
+        .build()
+        .unwrap();
+
+    let stream = client.stream::<Row>("SELECT * FROM t".to_string());
+    tokio::pin!(stream);
+
+    let mut rows = Vec::new();
+    while let Some(item) = stream.next().await {
+        rows.push(item.expect("stream item should be Ok"));
+    }
+
+    // 2 rows from page 2 + 1 row from page 3, without ever buffering the whole set.
+    assert_eq!(rows.len(), 3, "expected 3 rows streamed across 3 pages");
+
+    server.verify().await;
+}
+
+#[tokio::test]
+async fn test_stream_surfaces_query_error() {
+    let (server, host, port) = make_mock_server().await;
+    let uri = server.uri();
+
+    let page1 = json!({
+        "id": "test_stream_err",
+        "infoUri": format!("{uri}/ui/query.html?test_stream_err"),
+        "nextUri": format!("{uri}/v1/statement/test_stream_err/1"),
+        "stats": read_fixture("query_result_finished")["stats"].clone(),
+        "warnings": []
+    });
+    // Error page carried inside a 200 response (Trino reports query errors this way).
+    let err_page = read_fixture("query_result_failed");
+
+    Mock::given(method("POST"))
+        .and(path("/v1/statement"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(page1))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/v1/statement/test_stream_err/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(err_page))
+        .mount(&server)
+        .await;
+
+    let client = ClientBuilder::new("test_user", host)
+        .port(port)
+        .build()
+        .unwrap();
+
+    let stream = client.stream::<Row>("SELECT * FROM t".to_string());
+    tokio::pin!(stream);
+
+    let mut saw_error = false;
+    while let Some(item) = stream.next().await {
+        if item.is_err() {
+            saw_error = true;
+            break;
+        }
+    }
+    assert!(saw_error, "a query error page must surface as an Err item");
+}


### PR DESCRIPTION
Implements the streaming row API from the roadmap (private tracking issue nudibranches-tech/hyperfluid#3105, epic #3114).

## Why
`get_all` accumulates **every** row in memory before returning. Trino serves big result sets, so a large `SELECT` can OOM the client. This is the top scalability gap as adoption grows.

## What
`Client::stream::<T>(sql).await?` returns a **`RowStream`** that:
- **resolves the result schema up front** — `rows.columns()` gives `&[(String, TrinoTy)]` before the first row is pulled;
- implements `futures::Stream<Item = Result<T>>`, following Trino's `nextUri` chain **on demand** (backpressured: a page is fetched only once the previous one is drained);
- is `Unpin` (inner stream is boxed), so **no `tokio::pin!` needed**.

```rust
use futures::StreamExt;
let mut rows = client.stream::<Row>("SELECT ...").await?;
println!("schema: {:?}", rows.columns());
while let Some(row) = rows.next().await {
    let row = row?;
}
```

- Works for `Row` and derived `#[derive(Trino)]` types.
- Direct **and** Spooled protocols (spooled rows materialized one segment at a time — peak memory bounded).
- Query-error pages surface as `Err` items (or eagerly at `stream().await` if the failure happens before the schema resolves).
- Per-page Trino error mapping extracted into a shared `map_page_error`.

## Design notes (from self-review)
- Schema-up-front satisfies the issue's acceptance criteria; `stream()` is async because it drives the query far enough to learn the columns before returning.
- Relaxed vs `get_all`: does not reject a query mixing Direct/Spooled across pages (documented).
- **Cancellation:** dropping an unfinished `RowStream` stops fetching but does not cancel the query server-side — documented, with a real cancel-on-drop tracked as a follow-up (nudibranches-tech/hyperfluid#3116).
- Uses `async-stream` (tokio-rs, de-facto standard); measured marginal cost is only `async-stream-impl` — no new transitive deps.

## Tests
- `tests/stream.rs`: multi-page streaming (schema asserted up front + 3 rows), empty result set (schema, zero rows), mid-stream error (rows then `Err`).
- `examples/stream.rs`; doctest on `stream` compiles.
- Full suite green (default + `--features spooling`), clippy `-D warnings` clean (all targets).