### PR TITLE
chore: trim tokio to rt+sync features in the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 ### Added
 - `Client::stream` — lazily stream query rows page by page without buffering the whole result set in memory (Direct and Spooled protocols). Returns a `RowStream` that resolves the result columns up front (`RowStream::columns() -> &[Column]`), implements `futures::Stream`, is `Send`/`Unpin`, and best-effort cancels the query on the coordinator if dropped before completion
 
+### Changed
+- The library now depends on `tokio` with only the `rt` and `sync` features instead of `full`, shrinking the dependency footprint and compile time for consumers (no longer pulls `fs`/`process`/`signal`/…). Tests and examples keep the fuller feature set via dev-dependencies
+
 ## [0.10.0] - 2026-07-18
 ### Security
 - Updated dependencies to remediate 13 RustSec advisories in transitive crates, including `aws-lc-sys` (X.509/PKCS7 validation bypasses, timing side-channel), `quinn-proto` (DoS, memory exhaustion), `rustls-webpki` (CRL/name-constraint validation, parsing panic), `bytes` (integer overflow) and `slab` (out-of-bounds, yanked) [#44](https://github.com/nudibranches-tech/trino-rust-client/pull/44)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ zstd = {workspace = true, optional = true}
 [dev-dependencies]
 dotenvy = "0.15"
 maplit = "1.0"
+# The library itself only needs a minimal tokio; tests and examples need the
+# runtime, macros and timers.
+tokio = {workspace = true, features = ["macros", "rt-multi-thread", "time"]}
 trybuild = "1.0.112"
 wiremock = "0.6.5"
 
@@ -85,7 +88,7 @@ reqwest = {version = "0.13.4", default-features = false, features = ["rustls", "
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0.150"
 thiserror = "2.0.18"
-tokio = {version = "1.53", features = ["full"]}
+tokio = {version = "1.53", features = ["rt", "sync"]}
 tracing-subscriber = {version = "0.3.23", default-features = false, features = ["fmt", "env-filter"]}
 trino-rust-client-macros = {version = "0.7.2", path = "trino-rust-client-macros"}
 url = "2.5.8"

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -2,7 +2,7 @@
 futures = {workspace = true}
 log = {workspace = true}
 reqwest = {workspace = true}
-tokio = {workspace = true}
+tokio = {workspace = true, features = ["macros", "rt-multi-thread"]}
 tracing-subscriber = {workspace = true}
 trino-rust-client = {path = "..", features = ["spooling"]}
 uuid = {workspace = true}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use backon::ExponentialBuilder;
 use backon::Retryable;
@@ -12,7 +13,6 @@ use log::*;
 use reqwest::header::HeaderValue;
 use reqwest::{RequestBuilder, Response, Url};
 use tokio::sync::RwLock;
-use tokio::time::Duration;
 
 use crate::auth::Auth;
 use crate::build_dataset;


### PR DESCRIPTION
Roadmap item nudibranches-tech/hyperfluid#3106 (epic #3114).

## Why
The library depended on `tokio = { features = ["full"] }`, forcing every consumer to compile the entire tokio (fs, process, signal, rt-multi-thread, io-std, …) even though the library uses almost none of it.

## What the library actually uses
- `tokio::sync::RwLock` → `sync`
- `tokio::runtime::Handle` + `spawn` (cancel-on-drop) → `rt`
- `tokio::time::Duration` → switched to `std::time::Duration` (identical type), so `time` is not needed

## Change
- `tokio` dependency: `["full"]` → `["rt", "sync"]`.
- Tests & examples keep `macros`/`rt-multi-thread`/`time` via **dev-dependencies**; integration tests declare `macros`/`rt-multi-thread`.

## Effect (measured)
For a normal (non-dev) build, tokio now resolves to `bytes, io-util, mio, net, rt, socket2, sync, time` (the rest pulled transitively by reqwest/hyper) — **no longer** `fs`, `process`, `signal`, `io-std`, `rt-multi-thread` on our account.

## Verification
- `cargo build --lib` (default + `--features spooling`) ✅
- Full test suite green (76 tests incl. 6 stream), examples compile, integration tests compile, clippy `-D warnings` clean.