### PR TITLE
docs: crate-level docs, quickstart, and core API documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 ### Added
 - `Client::get_all`, `Client::get` and `Client::execute` now accept `impl Into<String>` for the SQL, so `&str` literals work without `.to_string()` (consistent with `Client::stream`). Existing `String` call sites are unaffected
 - `VarBinary` type for Trino `VARBINARY` columns — decodes/encodes the base64 wire format into raw bytes (`base64` is now a core dependency). Confirmed that `Json` (`serde_json::Value`) and `TimestampWithTimeZone` (`chrono::DateTime<FixedOffset>`) already decode, and added tests
+- Crate-level documentation with a runnable quickstart, and doc comments on the core public API (`Client`, `ClientBuilder`, `get_all`/`get`/`get_next`/`cancel`, `ExecuteResult`). docs.rs now builds with all features
 - `QueryError::kind()` returning a `#[non_exhaustive]` `TrinoErrorKind` enum, for ergonomic, discoverable matching on the common Trino error names (`TableNotFound`, `SchemaNotFound`, `SyntaxError`, …) without comparing raw strings; falls back to `TrinoErrorKind::Other`
 - `Client::stream` — lazily stream query rows page by page without buffering the whole result set in memory (Direct and Spooled protocols). Returns a `RowStream` that resolves the result columns up front (`RowStream::columns() -> &[Column]`), implements `futures::Stream`, is `Send`/`Unpin`, and best-effort cancels the query on the coordinator if dropped before completion
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,10 @@ readme = "README.md"
 repository = {workspace = true}
 version = {workspace = true}
 
+[package.metadata.docs.rs]
+# Build docs on docs.rs with every feature so the spooling API is included.
+all-features = true
+
 [[test]]
 name = "spooling_protocol"
 path = "tests/spooling_protocol.rs"

--- a/src/client.rs
+++ b/src/client.rs
@@ -37,6 +37,13 @@ use crate::{DataSet, QueryResult, Row, Trino};
 // allow_redirects
 // proxies
 
+/// A configured Trino client.
+///
+/// Created with [`ClientBuilder`]. Cheap to share: it wraps a connection-pooled
+/// HTTP client, so build one and reuse it for all queries. The main entry
+/// points are [`get_all`](Client::get_all) (buffer the result),
+/// [`stream`](Client::stream) (stream it lazily) and [`execute`](Client::execute)
+/// (run a statement).
 pub struct Client {
     client: reqwest::Client,
     session: RwLock<Session>,
@@ -47,6 +54,22 @@ pub struct Client {
     segment_fetcher: SegmentFetcher,
 }
 
+/// Builder for a [`Client`].
+///
+/// Start with [`ClientBuilder::new`], chain the setters you need, then call
+/// [`build`](ClientBuilder::build).
+///
+/// ```no_run
+/// # use trino_rust_client::client::ClientBuilder;
+/// # fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// let client = ClientBuilder::new("user", "trino.example.com")
+///     .port(8443)
+///     .secure(true)
+///     .catalog("hive")
+///     .schema("default")
+///     .build()?;
+/// # Ok(()) }
+/// ```
 pub struct ClientBuilder {
     session: SessionBuilder,
     auth: Option<Auth>,
@@ -60,14 +83,22 @@ pub struct ClientBuilder {
     max_concurrent_segments: Option<usize>,
 }
 
+/// Outcome of a statement run with [`Client::execute`].
 #[derive(Debug)]
 pub struct ExecuteResult {
+    /// URI of the output, when the statement produces one.
     pub output_uri: Option<String>,
+    /// The kind of update (e.g. `INSERT`, `CREATE TABLE`), if reported.
     pub update_type: Option<String>,
+    /// Number of rows affected, if reported.
     pub update_count: Option<u64>,
 }
 
 impl ClientBuilder {
+    /// Start building a client for the given Trino `user` and `host`.
+    ///
+    /// Defaults: port 8080, plain HTTP, no authentication. Use the setters to
+    /// change them, then call [`build`](ClientBuilder::build).
     pub fn new(user: impl ToString, host: impl ToString) -> Self {
         let builder = SessionBuilder::new(user, host);
         Self {
@@ -675,6 +706,11 @@ impl Client {
         })
     }
 
+    /// Run `sql` and return the whole result set as a [`DataSet`].
+    ///
+    /// The entire result is buffered in memory — for large results prefer
+    /// [`stream`](Client::stream). `T` is a `#[derive(Trino)]` row struct, or
+    /// [`Row`] for a dynamically-typed result.
     #[tracing::instrument(skip_all, fields(query_id = tracing::field::Empty))]
     pub async fn get_all<T>(&self, sql: impl Into<String>) -> Result<DataSet<T>>
     where
@@ -979,6 +1015,12 @@ impl Client {
         result.retry(self.retry_policy()).when(need_retry).await
     }
 
+    /// Submit `sql` and return the first result page.
+    ///
+    /// Low-level building block: the returned [`QueryResult`] may carry a
+    /// `next_uri` that you must follow with [`get_next`](Client::get_next) to
+    /// retrieve the rest. Most callers should use [`get_all`](Client::get_all)
+    /// or [`stream`](Client::stream), which handle pagination.
     pub async fn get<T>(&self, sql: impl Into<String>) -> Result<QueryResult<T>>
     where
         T: Trino + 'static,
@@ -1004,6 +1046,8 @@ impl Client {
         .await
     }
 
+    /// Fetch the next result page from a `next_uri` returned by a previous
+    /// [`get`](Client::get) / `get_next` call.
     pub async fn get_next<T>(&self, url: &str) -> Result<QueryResult<T>>
     where
         T: Trino + 'static,
@@ -1025,6 +1069,8 @@ impl Client {
         .await
     }
 
+    /// Cancel a running query by its id, releasing its resources on the
+    /// coordinator.
     pub async fn cancel(&self, query_id: &str) -> Result<()> {
         let url = format!("{}v1/query/{}", self.url, query_id);
         let req = self.client.delete(url);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,75 @@
+//! An async [Trino](https://trino.io/) client.
+//!
+//! Build a [`Client`] with [`ClientBuilder`],
+//! then run queries. Rows deserialize into a `#[derive(Trino)]` struct for
+//! statically-known schemas, or into [`Row`] when the shape is only known at
+//! runtime.
+//!
+//! # Quickstart
+//!
+//! ```no_run
+//! use trino_rust_client::{client::ClientBuilder, Trino};
+//! use futures::StreamExt;
+//! use serde::{Deserialize, Serialize};
+//!
+//! // A result row type needs `Trino` (column mapping) plus serde's derives.
+//! #[derive(Trino, Debug, Deserialize, Serialize)]
+//! struct Nation {
+//!     nationkey: i64,
+//!     name: String,
+//! }
+//!
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = ClientBuilder::new("user", "localhost")
+//!     .port(8080)
+//!     .catalog("tpch")
+//!     .schema("sf1")
+//!     .build()?;
+//!
+//! // Buffer the whole result set:
+//! let nations = client.get_all::<Nation>("SELECT nationkey, name FROM nation").await?;
+//! for n in nations.as_slice() {
+//!     println!("{n:?}");
+//! }
+//!
+//! // …or stream it lazily, without holding the whole result in memory:
+//! let mut rows = client.stream::<Nation>("SELECT nationkey, name FROM nation").await?;
+//! while let Some(row) = rows.next().await {
+//!     println!("{:?}", row?);
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Result types
+//!
+//! - `#[derive(Trino)]` structs — decode columns by name into typed fields.
+//! - [`Row`] — a dynamically-typed row when the schema is not known at compile
+//!   time; pair it with [`DataSet`] to keep the column metadata.
+//!
+//! # Error handling
+//!
+//! All fallible calls return [`error::Error`]. A query failure from the
+//! coordinator is [`error::Error::Query`]; match on
+//! [`QueryError::kind`](models::QueryError::kind) for common cases such as
+//! `TableNotFound`. See the [`error`] module for details.
+//!
+//! # Cargo features
+//!
+//! - `spooling` — support Trino's spooling protocol for large result sets
+//!   (segments fetched from object storage), enabling
+//!   [`ClientBuilder::spooling_encoding`](client::ClientBuilder::spooling_encoding)
+//!   and related options.
+//!
+//! # Observability
+//!
+//! The client emits [`tracing`](https://docs.rs/tracing) events and wraps each
+//! query in a span carrying its `query_id`. Install any `tracing` subscriber to
+//! see them.
+//!
+//! Upgrading across a breaking release? See the [migration guide][mg].
+//!
+//! [mg]: https://github.com/nudibranches-tech/trino-rust-client/blob/main/MIGRATION.md
 #![allow(clippy::should_implement_trait)]
 #![allow(clippy::derivable_impls)]
 


### PR DESCRIPTION
Roadmap item nudibranches-tech/hyperfluid#3112 (epic #3114). Non-breaking (docs only).

## What
- **Crate-level docs** (`lib.rs`): overview + **runnable quickstart** (derive a row type → `get_all` and `stream`), plus sections on result types, error handling, cargo features and observability, and a link to the migration guide.
- **Core public API doc comments**: `Client`, `ClientBuilder` (+ `new`/`build` with an example), `get_all`, `get`/`get_next` (with pagination guidance), `cancel`, `ExecuteResult`. (`RowStream`, `RetryPolicy`, the `error` module and `QueryError::kind` were already documented in earlier PRs.)
- **docs.rs metadata**: `all-features = true` so the spooling API is documented.

## Scope note
This is the **high-value** documentation. A full `#![deny(missing_docs)]` gate would require documenting ~370 public items — the bulk being the Trino type-system internals in `types/` and model struct fields that mirror the wire JSON. Forcing docs there produces filler, so the completeness gate is intentionally deferred (tracked in #3112).

## Verification
- `cargo doc --no-deps --all-features` builds clean with `RUSTDOCFLAGS=-D warnings` (no broken intra-doc links).
- All doctests pass (incl. the new crate quickstart); clippy `-D warnings` clean.