### PR TITLE
feat: accept impl Into<String> for SQL parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 > Upgrading from 0.10.x? See the [migration guide](MIGRATION.md).
 
 ### Added
+- `Client::get_all`, `Client::get` and `Client::execute` now accept `impl Into<String>` for the SQL, so `&str` literals work without `.to_string()` (consistent with `Client::stream`). Existing `String` call sites are unaffected
 - `QueryError::kind()` returning a `#[non_exhaustive]` `TrinoErrorKind` enum, for ergonomic, discoverable matching on the common Trino error names (`TableNotFound`, `SchemaNotFound`, `SyntaxError`, …) without comparing raw strings; falls back to `TrinoErrorKind::Other`
 - `Client::stream` — lazily stream query rows page by page without buffering the whole result set in memory (Direct and Spooled protocols). Returns a `RowStream` that resolves the result columns up front (`RowStream::columns() -> &[Column]`), implements `futures::Stream`, is `Send`/`Unpin`, and best-effort cancels the query on the coordinator if dropped before completion
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -676,12 +676,12 @@ impl Client {
     }
 
     #[tracing::instrument(skip_all, fields(query_id = tracing::field::Empty))]
-    pub async fn get_all<T>(&self, sql: String) -> Result<DataSet<T>>
+    pub async fn get_all<T>(&self, sql: impl Into<String>) -> Result<DataSet<T>>
     where
         T: Trino + 'static,
         for<'de> T: serde::Deserialize<'de> + serde::Serialize,
     {
-        let res = self.get_retry(sql).await?;
+        let res = self.get_retry(sql.into()).await?;
         tracing::Span::current().record("query_id", res.id.as_str());
 
         // Store columns from responses (used for Direct protocol DataSet construction)
@@ -905,9 +905,9 @@ impl Client {
      * @return [`Result<ExecuteResult>`]` The result of the execution
      * */
     #[tracing::instrument(skip_all, fields(query_id = tracing::field::Empty))]
-    pub async fn execute(&self, sql: String) -> Result<ExecuteResult> {
+    pub async fn execute(&self, sql: impl Into<String>) -> Result<ExecuteResult> {
         // try the sql first
-        let res = self.get_retry::<Row>(sql).await?;
+        let res = self.get_retry::<Row>(sql.into()).await?;
         tracing::Span::current().record("query_id", res.id.as_str());
 
         let mut next = res.next_uri;
@@ -979,7 +979,7 @@ impl Client {
         result.retry(self.retry_policy()).when(need_retry).await
     }
 
-    pub async fn get<T>(&self, sql: String) -> Result<QueryResult<T>>
+    pub async fn get<T>(&self, sql: impl Into<String>) -> Result<QueryResult<T>>
     where
         T: Trino + 'static,
         for<'de> T: serde::Deserialize<'de>,
@@ -987,7 +987,7 @@ impl Client {
         let req = self
             .client
             .post(format!("{}v1/statement", self.url))
-            .body(sql);
+            .body(sql.into());
         let req = {
             let session = self.session.read().await;
             add_session_header(req, &session)

--- a/tests/get_all_empty.rs
+++ b/tests/get_all_empty.rs
@@ -73,7 +73,7 @@ async fn test_get_all_empty_result_set_row_type() {
         .unwrap();
 
     let result = client
-        .get_all::<Row>("SELECT a, b, c, d, e, f FROM t WHERE 1=0".to_string())
+        .get_all::<Row>("SELECT a, b, c, d, e, f FROM t WHERE 1=0")
         .await;
 
     assert!(
@@ -109,7 +109,7 @@ async fn test_get_all_empty_result_set_derived_type() {
         .unwrap();
 
     let result = client
-        .get_all::<Record>("SELECT a, b, c, d, f FROM t WHERE 1=0".to_string())
+        .get_all::<Record>("SELECT a, b, c, d, f FROM t WHERE 1=0")
         .await;
 
     assert!(


### PR DESCRIPTION
Roadmap item nudibranches-tech/hyperfluid#3111 (epic #3114). Non-breaking (additive).

## What
`Client::get_all`, `Client::get` and `Client::execute` now take `impl Into<String>` for the SQL text — matching `Client::stream`, which already did. Callers can pass `&str` literals without `.to_string()`:

```rust
client.get_all::<Row>("SELECT 1").await?;   // was: "SELECT 1".to_string()
```

Existing `String` call sites keep compiling (`String: Into<String>`).

## Tests
- Updated the `get_all_empty` tests to pass `&str` literals directly, exercising the new signature end-to-end.
- Full check + clippy `-D warnings` clean.