### PR TITLE
chore: add CLAUDE.md and a release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: release
+description: Cut a new release of trino-rust-client and publish it to crates.io. Use when asked to release a version, bump the version, or publish the crate.
+---
+
+# Releasing trino-rust-client
+
+Follow these steps in order. The tag (created by the GitHub Release, **not**
+locally) triggers `.github/workflows/crate-release.yaml`, which publishes to
+crates.io.
+
+## 1. Decide the version
+
+Pre-1.0 semver: a `## [Unreleased]` section containing any **Breaking:** entry
+bumps the **minor** (`0.10 → 0.11`); otherwise bump the **patch**. Read
+`CHANGELOG.md` to decide.
+
+## 2. Check EVERY published sub-crate (easy to miss — it broke 0.10.0)
+
+The workspace publishes **two** crates: `trino-rust-client` and
+`trino-rust-client-macros` (the macros crate has its **own** version, not
+workspace-inherited). If `trino-rust-client-macros/` changed since its last
+publish, bump its `version` **and** the `workspace.dependencies.trino-rust-client-macros`
+reference — otherwise `katyo/publish-crates` fails the whole release with
+`package 'trino-rust-client-macros' modified since 'X'`.
+
+## 3. Prepare the release branch
+
+```bash
+git checkout -b release/X.Y.Z
+```
+
+- Bump `workspace.package.version` in `Cargo.toml` to `X.Y.Z`.
+- Finalize `CHANGELOG.md`: turn `## [Unreleased]` into `## [X.Y.Z] - <date>`
+  (leave an empty `[Unreleased]` above it) and add the comparison link at the
+  bottom (**no `v` prefix** — tags are `X.Y.Z`, e.g. `compare/0.10.0...0.11.0`).
+- Update the version in `README.md` install snippets (there are two).
+- If the release has breaking changes, make sure `MIGRATION.md` covers them.
+- `cargo check` and `cargo check --features spooling`.
+- Commit `release X.Y.Z`, push the branch, open a PR.
+
+## 4. After the PR is merged — create the GitHub Release
+
+```bash
+gh release create X.Y.Z --target main --title "X.Y.Z 🌈" \
+  --notes-file <changelog-section> --latest
+```
+
+- **Tag: `X.Y.Z`** — no `v` prefix (matches every prior tag and the publish workflow).
+- **Title: `X.Y.Z 🌈`** — the rainbow is required (matches release-drafter's
+  `name-template`). Do not drop it.
+- **Notes**: the CHANGELOG entries for this version + a
+  `**Full Changelog**: .../compare/<prev>...<this>` link (non-`v` tags).
+
+Creating the tag triggers the publish workflow (~4 min). Watch it:
+
+```bash
+gh run watch <run-id> --exit-status
+```
+
+Then confirm both crates on crates.io (`trino-rust-client` and
+`trino-rust-client-macros`).
+
+## Notes
+
+- Do **not** create git tags locally — the GitHub Release creates them.
+- Git SSH is not configured; use `gh` for remote operations.
+- release-drafter maintains a rolling draft named `X.Y.Z 🌈`; that is expected,
+  not a stale artifact.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md
+
+Guidance for working in this repository.
+
+## Build & test
+
+```bash
+cargo check                       # default features
+cargo check --features spooling   # spooling protocol support
+cargo test --features spooling    # unit + integration tests
+cargo clippy --all-features --all-targets -- -D warnings
+```
+
+Always verify **both** feature configurations (`default` and `spooling`). The
+`spooling` codec dependencies are gated behind the feature; `base64` is a core
+dependency (needed by `VarBinary`).
+
+## Workflow
+
+- **Never commit directly to `main`.** Pre-commit hooks (`.pre-commit-config.yaml`)
+  block it and run `rustfmt`, `cargo check --all-features` and
+  `clippy -D warnings`. Always work on a branch and open a PR.
+- Git SSH is not configured — use the `gh` CLI (or `gh auth git-credential`) for
+  remote git operations.
+- Keep `CHANGELOG.md` (`## [Unreleased]`) updated for user-facing changes; mark
+  breaking changes **Breaking:** and add before/after notes to `MIGRATION.md`.
+
+## Architecture
+
+Async Trino client. Build a [`Client`] with `ClientBuilder`, then query.
+
+### Query entry points (`src/client.rs`)
+- `get_all<T>` — run a query and buffer the whole result into a `DataSet<T>`.
+- `stream<T>` — lazily stream rows as a `RowStream` (`futures::Stream`), resolving
+  the schema up front (`columns()`), `Send`/`Unpin`, and best-effort cancelling
+  the query on early drop.
+- `execute` — run a statement, returns `ExecuteResult`.
+- `get` / `get_next` — low-level single-page pagination (`next_uri`).
+
+Results are paginated: a response carries a `next_uri` to follow. Retries use
+`RetryPolicy` and are **idempotency-aware**: page fetches (GET) retry on any
+transient failure, query submission (POST) only when definitely not processed.
+
+### Data protocols (`QueryResultData<T>`)
+- **Direct**: inline JSON rows.
+- **Spooled** (`feature = "spooling"`): compressed segments fetched from object
+  storage; decoded one segment at a time.
+
+### Type system (`src/types/`)
+- The `Trino` trait maps a Rust type to a `TrinoTy` and provides a
+  `DeserializeSeed`. `RawTrinoTy` (`src/models/ty.rs`) parses Trino's wire type
+  strings; `TrinoTy::from_type_signature` converts them. Unmapped types produce
+  `Error::UnsupportedType(name)`.
+- `#[derive(Trino)]` (in `trino-rust-client-macros`, a **separately versioned**
+  crate) generates the impl for a row struct. A row struct also needs
+  `serde::{Deserialize, Serialize}`.
+- `Row` — dynamically-typed row (`TrinoTy::Unknown`), pairs with `DataSet`.
+
+### Errors (`src/error.rs`, `src/models/error.rs`)
+- `Error` is `#[non_exhaustive]`. A query failure is `Error::Query(Box<QueryError>)`
+  (structured; match on `error_code`/`error_name`, or `QueryError::kind()`).
+  `Error::Decode` / `Tls` / `Protocol` cover typed failure classes;
+  `InternalError` is for genuinely unexpected cases.
+
+### Observability
+- Emits `tracing` events; `get_all`/`stream`/`execute` are wrapped in a span
+  carrying the `query_id`.
+
+## Conventions
+
+- Feature-gate spooling code with `#[cfg(feature = "spooling")]` and test both paths.
+- Tests for `client.rs` internals go in its bottom `mod tests`; integration tests
+  live in `tests/` (wiremock for HTTP, fixtures in `tests/data/models/`).
+- Releases follow the process in the `release` skill (`.claude/skills/release/`).


### PR DESCRIPTION
Adds two repo-tooling files (docs only, no code):

- **`CLAUDE.md`** — up-to-date architecture guide (streaming `RowStream`, structured `Error::Query`, idempotency-aware retries, the type system, spooling), build/test commands, and the branch-only + pre-commit workflow.
- **`.claude/skills/release/SKILL.md`** — codifies the release process, including the gotchas that broke 0.10.0: bump the separately-versioned `trino-rust-client-macros` crate, tags without a `v` prefix, and the `X.Y.Z 🌈` release title.

(Supersedes the stale CLAUDE.md that #36 would have added, which described an `Accumulator` design that was never built.)