### PR TITLE
ci: declare MSRV 1.86 and polish workflows

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -13,7 +13,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-audit
       - name: Run cargo audit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest]
         rust: [stable, nightly]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install latest ${{ matrix.rust }}
         uses: dtolnay/rust-toolchain@master
@@ -38,3 +38,13 @@ jobs:
 
       - name: Run integration tests
         run: cargo test --package trino-integration-tests
+
+  msrv:
+    name: Minimum supported Rust version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      # Keep this in sync with `rust-version` in Cargo.toml.
+      - uses: dtolnay/rust-toolchain@1.86.0
+      - name: Check on the MSRV toolchain
+        run: cargo check --all-features

--- a/.github/workflows/crate-release.yaml
+++ b/.github/workflows/crate-release.yaml
@@ -8,7 +8,7 @@ jobs:
     release:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - uses: dtolnay/rust-toolchain@stable
         - uses: katyo/publish-crates@v2
           with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Rust
       id: rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 - `Client::stream` — lazily stream query rows page by page without buffering the whole result set in memory (Direct and Spooled protocols). Returns a `RowStream` that resolves the result columns up front (`RowStream::columns() -> &[Column]`), implements `futures::Stream`, is `Send`/`Unpin`, and best-effort cancels the query on the coordinator if dropped before completion
 
 ### Changed
+- Declared a minimum supported Rust version (MSRV) of **1.86** and added a CI job that enforces it
 - Unsupported Trino column types now fail with `Error::UnsupportedType` naming the type (e.g. `unsupported Trino type: HyperLogLog`) instead of a generic error
 - Switched logging from the `log` crate to [`tracing`](https://docs.rs/tracing): the same events are now emitted via `tracing`, and `get_all` / `stream` / `execute` are wrapped in a span carrying the `query_id` for per-query correlation. Install a `tracing` subscriber to see them
 - The library now depends on `tokio` with only the `rt` and `sync` features instead of `full`, shrinking the dependency footprint and compile time for consumers (no longer pulls `fs`/`process`/`signal`/…). Tests and examples keep the fuller feature set via dev-dependencies
@@ -107,12 +108,12 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 ## [0.1.0] - 2020-10-01
 - Initial release
 
-[Unreleased]: https://github.com/nudibranches-tech/trino-rust-client/compare/v0.10.0...HEAD
-[0.10.0]: https://github.com/nudibranches-tech/trino-rust-client/compare/v0.9.3...v0.10.0
-[0.9.3]: https://github.com/nudibranches-tech/trino-rust-client/compare/v0.9.2...v0.9.3
-[0.9.2]: https://github.com/nudibranches-tech/trino-rust-client/compare/v0.9.1...v0.9.2
-[0.9.1]: https://github.com/nudibranches-tech/trino-rust-client/compare/v0.8.0...v0.9.1
-[0.8.0]: https://github.com/nudibranches-tech/trino-rust-client/compare/v0.5.1...v0.8.0
+[Unreleased]: https://github.com/nudibranches-tech/trino-rust-client/compare/0.10.0...HEAD
+[0.10.0]: https://github.com/nudibranches-tech/trino-rust-client/compare/0.9.3...0.10.0
+[0.9.3]: https://github.com/nudibranches-tech/trino-rust-client/compare/0.9.2...0.9.3
+[0.9.2]: https://github.com/nudibranches-tech/trino-rust-client/compare/0.9.1...0.9.2
+[0.9.1]: https://github.com/nudibranches-tech/trino-rust-client/compare/0.8.0...0.9.1
+[0.8.0]: https://github.com/nudibranches-tech/trino-rust-client/compare/0.5.1...0.8.0
 [0.5.1]: https://github.com/nooberfsh/prusto/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/nooberfsh/prusto/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/nooberfsh/prusto/compare/v0.3.0...v0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ license = {workspace = true}
 name = "trino-rust-client"
 readme = "README.md"
 repository = {workspace = true}
+rust-version = {workspace = true}
 version = {workspace = true}
 
 [package.metadata.docs.rs]
@@ -106,4 +107,5 @@ edition = "2021"
 homepage = "https://github.com/nudibranches-tech/trino-rust-client"
 license = "MIT"
 repository = "https://github.com/nudibranches-tech/trino-rust-client"
+rust-version = "1.86"
 version = "0.10.0"


### PR DESCRIPTION
Roadmap item nudibranches-tech/hyperfluid#3113 (epic #3114). Non-breaking.

## Changes
- **MSRV**: declared `rust-version = "1.86"` in `[workspace.package]` (inherited by the crate). 1.86 is the floor imposed by transitive dependencies — the `icu_*` crates via `url`/`idna` require it. **Verified** by building the workspace with a 1.86 toolchain. Added a CI `msrv` job (`dtolnay/rust-toolchain@1.86.0` + `cargo check --all-features`) to enforce it going forward.
- **CI**: bumped `actions/checkout@v4` → `@v5` across all workflows (the last Node-20-era action; #46 already migrated the rest off `actions-rs`).
- **CHANGELOG**: fixed the comparison links for this repo to drop the `v` prefix — our tags are `X.Y.Z`, not `vX.Y.Z`, so every compare link was broken. (Links pointing at the upstream `nooberfsh/prusto`, which used `v`-tags, are left as-is.)

## Verification
- `cargo check` on **1.86.0** builds clean (installed the toolchain and ran it).
- All workflow YAML parses.

## Notes
The MSRV job comment reminds to keep the pinned toolchain in sync with `Cargo.toml`.