### PR TITLE
fix: make Trino transactions usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## [Unreleased]
 
+### Added
+- `Client::begin_transaction`, `Client::commit` and `Client::rollback` for driving Trino transactions, plus `Client::transaction_id` / `Client::set_transaction_id` to inspect and set the session's transaction at runtime (previously only settable at build time via `ClientBuilder::transaction_id`)
+- `Error::Transaction` — returned when a transaction operation is attempted in a state that does not allow it (starting one while another is active, or committing/rolling back without one)
+- `TransactionId::is_active`
+
+### Fixed
+- **Transactions were unusable.** Trino returns a new transaction's identifier in `X-Trino-Started-Transaction-Id`, but the client parsed that header with a function that recognised only four fixed literals. A real identifier matched none of them and was silently discarded, so `START TRANSACTION` succeeded on the coordinator while every subsequent statement sent `X-Trino-Transaction-Id: NONE` and ran outside the transaction — and `COMMIT`/`ROLLBACK` could not address it. The identifier is now retained and sent on every subsequent request
+- Unparseable `X-Trino-Set-Role` header values are now logged instead of being dropped silently
+
+### Changed
+- **Breaking:** `TransactionId` now models what the `X-Trino-Transaction-Id` header actually carries: `NoTransaction | Id(String)`. The `StartTransaction`, `RollBack` and `Commit` variants are removed — they are SQL statements, not header values, and sending them produced a header Trino does not accept. `to_str` is replaced by `as_header_value(&self) -> &str` and `from_str` by the infallible `from_header_value(&str) -> Self`. `TransactionId` is no longer `Copy` (it now owns a `String`); it is still `Clone`, and now also `PartialEq` and `Eq`. See the [migration guide](MIGRATION.md)
+
 ## [0.11.0] - 2026-07-19
 
 > Upgrading from 0.10.x? See the [migration guide](MIGRATION.md).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,84 @@
 Guidance for upgrading across breaking releases. See [CHANGELOG.md](CHANGELOG.md)
 for the full list of changes.
 
+## 0.11.0 → 0.12.0
+
+### Transactions (`TransactionId` reshaped)
+
+`TransactionId` previously carried four fixed literals and could not represent a
+transaction identifier at all, which meant transactions did not work: the
+identifier Trino returned was silently discarded. It now models exactly what the
+`X-Trino-Transaction-Id` header carries.
+
+`StartTransaction`, `RollBack` and `Commit` are gone. They were SQL statements,
+not header values — code that set them was sending a header Trino does not
+accept, and was not in a transaction either way. Use the new `Client` methods.
+
+**Before:**
+
+```rust
+use trino_rust_client::transaction::TransactionId;
+
+let client = ClientBuilder::new("user", "localhost")
+    .transaction_id(TransactionId::StartTransaction)
+    .build()?;
+
+// ... and there was no way to commit: the id was never captured.
+```
+
+**After:**
+
+```rust
+client.begin_transaction().await?;
+client.execute("INSERT INTO t VALUES (1)").await?;
+client.commit().await?;   // or client.rollback().await?
+```
+
+To inspect or adopt a transaction directly:
+
+```rust
+use trino_rust_client::transaction::TransactionId;
+
+let id = client.transaction_id().await;       // TransactionId::Id(..) when active
+client.set_transaction_id(id).await;          // adopt one started elsewhere
+```
+
+Note both accessors are `async` — the session sits behind a `tokio::sync::RwLock`.
+
+If you match on `TransactionId`, the exhaustive set is now two variants:
+
+**Before:**
+
+```rust
+match id {
+    TransactionId::NoTransaction => { /* … */ }
+    TransactionId::StartTransaction => { /* … */ }
+    TransactionId::RollBack => { /* … */ }
+    TransactionId::Commit => { /* … */ }
+}
+```
+
+**After:**
+
+```rust
+match id {
+    TransactionId::NoTransaction => { /* … */ }
+    TransactionId::Id(uuid) => { /* … */ }
+}
+```
+
+### Accessor renames
+
+| Before | After | Note |
+|---|---|---|
+| `TransactionId::to_str(&self) -> &'static str` | `TransactionId::as_header_value(&self) -> &str` | cannot be `'static` now that a variant owns a `String` |
+| `TransactionId::from_str(&str) -> Option<Self>` | `TransactionId::from_header_value(&str) -> Self` | infallible: anything other than `NONE` is an identifier |
+
+### `TransactionId` is no longer `Copy`
+
+It owns a `String`. It is still `Clone`, and now also `PartialEq` and `Eq`. Add
+`.clone()` where you relied on implicit copies.
+
 ## 0.10.x → 0.11.0
 
 ### Error handling (restructured `Error` enum)

--- a/integration_tests/tests/transaction_test.rs
+++ b/integration_tests/tests/transaction_test.rs
@@ -35,9 +35,13 @@ async fn transaction_round_trip() {
         "Trino returned a transaction id but the client dropped it: {started:?}"
     );
 
-    // A statement inside the transaction must succeed. If the client were
-    // sending NONE, Trino would still answer, so the real assertion is that the
-    // COMMIT below resolves this same transaction.
+    // A statement inside the transaction must succeed. This does not prove it
+    // ran transactionally-scoped: Trino answers this query whether or not the
+    // transaction header is set, and committing an empty transaction succeeds
+    // either way. The wire-level proof that the identifier is actually sent
+    // lives in tests/transaction.rs; what this asserts is that a real
+    // coordinator issues an identifier, holds it across a statement, and
+    // clears it on COMMIT.
     let rows = client
         .get_all::<Row>("SELECT 1")
         .await

--- a/integration_tests/tests/transaction_test.rs
+++ b/integration_tests/tests/transaction_test.rs
@@ -1,0 +1,115 @@
+//! Round-trip of the Trino transaction protocol against a real coordinator.
+//!
+//! Transaction identifiers come from Trino's transaction manager rather than
+//! from a connector, so the `memory` catalog exercises the whole protocol.
+
+use trino_integration_tests::set_test_fixture;
+use trino_rust_client::transaction::TransactionId;
+use trino_rust_client::{ClientBuilder, Row};
+
+#[tokio::test]
+async fn transaction_round_trip() {
+    let fixture = set_test_fixture("transaction_round_trip");
+
+    let client = ClientBuilder::new("test", &fixture.coordinator_host)
+        .port(fixture.coordinator_port)
+        .catalog("memory")
+        .schema("default")
+        .build()
+        .expect("Failed to create client");
+
+    assert_eq!(
+        client.transaction_id().await,
+        TransactionId::NoTransaction,
+        "a fresh client must not be in a transaction"
+    );
+
+    client
+        .begin_transaction()
+        .await
+        .expect("START TRANSACTION failed");
+
+    let started = client.transaction_id().await;
+    assert!(
+        started.is_active(),
+        "Trino returned a transaction id but the client dropped it: {started:?}"
+    );
+
+    // A statement inside the transaction must succeed. If the client were
+    // sending NONE, Trino would still answer, so the real assertion is that the
+    // COMMIT below resolves this same transaction.
+    let rows = client
+        .get_all::<Row>("SELECT 1")
+        .await
+        .expect("SELECT inside transaction failed");
+    assert_eq!(rows.len(), 1);
+
+    assert_eq!(
+        client.transaction_id().await,
+        started,
+        "the transaction id must not change mid-transaction"
+    );
+
+    client.commit().await.expect("COMMIT failed");
+
+    assert_eq!(
+        client.transaction_id().await,
+        TransactionId::NoTransaction,
+        "COMMIT must clear the transaction id"
+    );
+}
+
+#[tokio::test]
+async fn rollback_ends_the_transaction() {
+    let fixture = set_test_fixture("rollback_ends_the_transaction");
+
+    let client = ClientBuilder::new("test", &fixture.coordinator_host)
+        .port(fixture.coordinator_port)
+        .catalog("memory")
+        .schema("default")
+        .build()
+        .expect("Failed to create client");
+
+    client
+        .begin_transaction()
+        .await
+        .expect("START TRANSACTION failed");
+    assert!(client.transaction_id().await.is_active());
+
+    client.rollback().await.expect("ROLLBACK failed");
+    assert_eq!(
+        client.transaction_id().await,
+        TransactionId::NoTransaction,
+        "ROLLBACK must clear the transaction id"
+    );
+}
+
+/// Trino rejects a second `START TRANSACTION`; the client rejects it locally,
+/// without a round trip.
+#[tokio::test]
+async fn nested_transactions_are_rejected() {
+    let fixture = set_test_fixture("nested_transactions_are_rejected");
+
+    let client = ClientBuilder::new("test", &fixture.coordinator_host)
+        .port(fixture.coordinator_port)
+        .catalog("memory")
+        .schema("default")
+        .build()
+        .expect("Failed to create client");
+
+    client
+        .begin_transaction()
+        .await
+        .expect("START TRANSACTION failed");
+
+    let err = client
+        .begin_transaction()
+        .await
+        .expect_err("nested transaction must be rejected");
+    assert!(
+        matches!(err, trino_rust_client::error::Error::Transaction(_)),
+        "expected Error::Transaction, got {err:?}"
+    );
+
+    client.rollback().await.expect("ROLLBACK failed");
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -404,7 +404,7 @@ fn add_session_header(mut builder: RequestBuilder, session: &Session) -> Request
         HEADER_PREPARED_STATEMENT,
         &session.prepared_statements,
     );
-    builder = builder.header(HEADER_TRANSACTION, session.transaction_id.to_str());
+    builder = builder.header(HEADER_TRANSACTION, session.transaction_id.as_header_value());
     builder = builder.header(HEADER_CLIENT_CAPABILITIES, "PATH,PARAMETRIC_DATETIME");
 
     // Add spooling header when feature is enabled
@@ -1176,12 +1176,15 @@ impl Client {
             resp
         );
 
-        set_header!(
-            session.transaction_id,
-            HEADER_STARTED_TRANSACTION_ID,
-            resp,
-            TransactionId::from_str
-        );
+        if let Some(v) = resp.headers().get(HEADER_STARTED_TRANSACTION_ID) {
+            match v.to_str() {
+                Ok(s) => session.transaction_id = TransactionId::from_header_value(s),
+                Err(e) => warn!(
+                    "parse header {} failed, reason: {}",
+                    HEADER_STARTED_TRANSACTION_ID, e
+                ),
+            }
+        }
         clear_header!(session.transaction_id, HEADER_CLEAR_TRANSACTION_ID, resp);
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -466,8 +466,10 @@ macro_rules! set_header_map {
     ($session:expr, $header:expr, $resp:expr, $from_str:expr) => {
         for v in $resp.headers().get_all($header) {
             if let Some((k, v)) = decode_kv_from_header(v) {
-                if let Some(v) = $from_str(&v) {
-                    $session.insert(k, v);
+                if let Some(parsed) = $from_str(&v) {
+                    $session.insert(k, parsed);
+                } else {
+                    warn!("parse header {} value '{}' failed, ignoring", $header, v)
                 }
             } else {
                 warn!("decode '{:?}' failed", v)

--- a/src/client.rs
+++ b/src/client.rs
@@ -1035,13 +1035,34 @@ impl Client {
     /// Start a transaction.
     ///
     /// Issues `START TRANSACTION` and captures the identifier Trino returns, so
-    /// every subsequent statement on this client runs inside the transaction
+    /// statements issued afterwards on this client run inside the transaction
     /// until [`commit`](Self::commit) or [`rollback`](Self::rollback).
+    ///
+    /// # Concurrency
+    ///
+    /// A transaction is a property of the whole client, so treat a client as
+    /// single-threaded for as long as one is open. Statements already in flight
+    /// when the transaction starts do not join it, and statements issued
+    /// concurrently from another task will run inside it whether or not that
+    /// was intended.
+    ///
+    /// The nesting check below is best-effort, not atomic: the session lock is
+    /// released before `START TRANSACTION` is sent (holding it would deadlock
+    /// against the write lock taken when the response is processed). Two tasks
+    /// calling this concurrently can therefore both pass the check and open two
+    /// transactions, of which only the last is retained — the other is orphaned
+    /// on the coordinator until it times out. Use a separate client per
+    /// transaction if you need concurrency.
     ///
     /// # Errors
     ///
     /// Returns [`Error::Transaction`] if a transaction is already active —
     /// Trino does not support nested transactions.
+    ///
+    /// On failure the transaction may nevertheless have been started, since the
+    /// identifier is captured before the statement finishes. Call
+    /// [`rollback`](Self::rollback) to discard it; that also clears an
+    /// identifier the coordinator has already expired.
     pub async fn begin_transaction(&self) -> Result<()> {
         // Bind the guard to a local: holding it across `execute` would deadlock
         // against the write lock `update_session` takes.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1016,6 +1016,79 @@ impl Client {
         })
     }
 
+    /// The transaction this client's session is currently bound to.
+    pub async fn transaction_id(&self) -> TransactionId {
+        self.session.read().await.transaction_id.clone()
+    }
+
+    /// Bind the session to a transaction.
+    ///
+    /// Normally unnecessary — [`begin_transaction`](Self::begin_transaction)
+    /// captures the identifier Trino issues. Use this to adopt a transaction
+    /// started elsewhere.
+    pub async fn set_transaction_id(&self, id: TransactionId) {
+        self.session.write().await.transaction_id = id;
+    }
+
+    /// Start a transaction.
+    ///
+    /// Issues `START TRANSACTION` and captures the identifier Trino returns, so
+    /// every subsequent statement on this client runs inside the transaction
+    /// until [`commit`](Self::commit) or [`rollback`](Self::rollback).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Transaction`] if a transaction is already active —
+    /// Trino does not support nested transactions.
+    pub async fn begin_transaction(&self) -> Result<()> {
+        // Bind the guard to a local: holding it across `execute` would deadlock
+        // against the write lock `update_session` takes.
+        let active = self.session.read().await.transaction_id.is_active();
+        if active {
+            return Err(Error::Transaction(
+                "a transaction is already active; Trino does not support nested transactions"
+                    .to_string(),
+            ));
+        }
+        self.execute("START TRANSACTION").await?;
+        Ok(())
+    }
+
+    /// Commit the active transaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Transaction`] if no transaction is active.
+    pub async fn commit(&self) -> Result<()> {
+        self.end_transaction("COMMIT").await
+    }
+
+    /// Roll back the active transaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Transaction`] if no transaction is active.
+    pub async fn rollback(&self) -> Result<()> {
+        self.end_transaction("ROLLBACK").await
+    }
+
+    /// Shared implementation of [`commit`](Self::commit) and
+    /// [`rollback`](Self::rollback).
+    ///
+    /// Trino answers either with `X-Trino-Clear-Transaction-Id`, which
+    /// `update_session` turns back into `TransactionId::NoTransaction`.
+    async fn end_transaction(&self, statement: &str) -> Result<()> {
+        let active = self.session.read().await.transaction_id.is_active();
+        if !active {
+            return Err(Error::Transaction(format!(
+                "no active transaction to {}",
+                statement.to_lowercase()
+            )));
+        }
+        self.execute(statement).await?;
+        Ok(())
+    }
+
     async fn try_get_retry_result(&self, url: &str) -> Result<TrinoRetryResult> {
         let response = self.client.get(url).send().await?;
 
@@ -1212,8 +1285,10 @@ mod tests {
     use http::StatusCode;
     use reqwest::header::HeaderValue;
 
+    use super::*;
     use crate::client::{decode_kv_from_header, need_retry_fetch, need_retry_submit};
     use crate::error::Error;
+    use crate::transaction::TransactionId;
 
     #[test]
     fn test_decode_kv_from_header_plus_sign_to_space() {
@@ -1277,5 +1352,53 @@ mod tests {
         assert!(!need_retry_submit(&http_not_ok(
             StatusCode::INTERNAL_SERVER_ERROR
         )));
+    }
+
+    #[tokio::test]
+    async fn transaction_id_defaults_to_no_transaction() {
+        let client = ClientBuilder::new("user", "localhost").build().unwrap();
+        assert_eq!(client.transaction_id().await, TransactionId::NoTransaction);
+    }
+
+    #[tokio::test]
+    async fn set_transaction_id_is_observable() {
+        let client = ClientBuilder::new("user", "localhost").build().unwrap();
+        let id = TransactionId::Id("17cbc429-462a-4da3-9a06-02b6507d0d01".to_string());
+        client.set_transaction_id(id.clone()).await;
+        assert_eq!(client.transaction_id().await, id);
+    }
+
+    #[tokio::test]
+    async fn begin_transaction_rejects_nesting() {
+        let client = ClientBuilder::new("user", "localhost").build().unwrap();
+        client
+            .set_transaction_id(TransactionId::Id("abc".to_string()))
+            .await;
+
+        let err = client.begin_transaction().await.unwrap_err();
+        assert!(
+            matches!(err, Error::Transaction(_)),
+            "expected Error::Transaction, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn commit_without_transaction_is_rejected() {
+        let client = ClientBuilder::new("user", "localhost").build().unwrap();
+        let err = client.commit().await.unwrap_err();
+        assert!(
+            matches!(err, Error::Transaction(_)),
+            "expected Error::Transaction, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rollback_without_transaction_is_rejected() {
+        let client = ClientBuilder::new("user", "localhost").build().unwrap();
+        let err = client.rollback().await.unwrap_err();
+        assert!(
+            matches!(err, Error::Transaction(_)),
+            "expected Error::Transaction, got {err:?}"
+        );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,11 @@ pub enum Error {
     /// data received without the `spooling` feature enabled).
     #[error("protocol error: {0}")]
     Protocol(String),
+    /// A transaction operation was attempted in a state that does not allow
+    /// it — starting a transaction while one is already active, or committing
+    /// or rolling back without one.
+    #[error("transaction error: {0}")]
+    Transaction(String),
     #[error("inconsistent data")]
     InconsistentData,
     #[error("reach max attempt: {0}")]

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,34 +1,91 @@
-#[derive(Debug, Copy, Clone)]
+/// The transaction a session is bound to.
+///
+/// This models the `X-Trino-Transaction-Id` request header, which carries
+/// either the `NONE` sentinel or a transaction identifier issued by Trino.
+///
+/// Trino returns the identifier of a newly started transaction in the
+/// `X-Trino-Started-Transaction-Id` response header; the client captures it
+/// automatically, so callers normally reach for
+/// [`Client::begin_transaction`](crate::client::Client::begin_transaction)
+/// rather than constructing this type by hand.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum TransactionId {
+    /// No transaction is active; requests send `NONE`.
+    #[default]
     NoTransaction,
-    StartTransaction,
-    RollBack,
-    Commit,
+    /// A transaction identifier issued by Trino.
+    Id(String),
 }
 
 impl TransactionId {
-    pub fn to_str(&self) -> &'static str {
-        use TransactionId::*;
-        match *self {
-            NoTransaction => "NONE",
-            StartTransaction => "START TRANSACTION",
-            RollBack => "ROLLBACK",
-            Commit => "COMMIT",
+    /// The value to send in the `X-Trino-Transaction-Id` request header.
+    pub fn as_header_value(&self) -> &str {
+        match self {
+            Self::NoTransaction => "NONE",
+            Self::Id(id) => id,
         }
     }
-    pub fn from_str(s: &str) -> Option<Self> {
+
+    /// Parse a value received from Trino.
+    ///
+    /// Infallible: anything that is not the `NONE` sentinel is a transaction
+    /// identifier. Trino does not document a fixed format for it, so no
+    /// validation is applied.
+    pub fn from_header_value(s: &str) -> Self {
         match s {
-            "NONE" => Some(Self::NoTransaction),
-            "START TRANSACTION" => Some(Self::StartTransaction),
-            "ROLLBACK" => Some(Self::RollBack),
-            "COMMIT" => Some(Self::Commit),
-            _ => None,
+            "NONE" => Self::NoTransaction,
+            other => Self::Id(other.to_string()),
         }
+    }
+
+    /// Whether a transaction is currently active.
+    pub fn is_active(&self) -> bool {
+        matches!(self, Self::Id(_))
     }
 }
 
-impl Default for TransactionId {
-    fn default() -> Self {
-        TransactionId::NoTransaction
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The bug this crate shipped in 0.11.0: a real UUID from
+    /// `X-Trino-Started-Transaction-Id` parsed to `None` and was discarded.
+    #[test]
+    fn uuid_is_retained_as_transaction_id() {
+        let uuid = "17cbc429-462a-4da3-9a06-02b6507d0d01";
+        assert_eq!(
+            TransactionId::from_header_value(uuid),
+            TransactionId::Id(uuid.to_string())
+        );
+    }
+
+    #[test]
+    fn none_sentinel_maps_to_no_transaction() {
+        assert_eq!(
+            TransactionId::from_header_value("NONE"),
+            TransactionId::NoTransaction
+        );
+    }
+
+    #[test]
+    fn header_value_round_trips() {
+        let uuid = "17cbc429-462a-4da3-9a06-02b6507d0d01";
+        let id = TransactionId::from_header_value(uuid);
+        assert_eq!(id.as_header_value(), uuid);
+        assert_eq!(TransactionId::from_header_value(id.as_header_value()), id);
+    }
+
+    #[test]
+    fn default_is_no_transaction_and_serialises_to_none() {
+        let id = TransactionId::default();
+        assert_eq!(id, TransactionId::NoTransaction);
+        assert_eq!(id.as_header_value(), "NONE");
+        assert!(!id.is_active());
+    }
+
+    #[test]
+    fn only_id_is_active() {
+        assert!(TransactionId::Id("abc".to_string()).is_active());
+        assert!(!TransactionId::NoTransaction.is_active());
     }
 }

--- a/tests/transaction.rs
+++ b/tests/transaction.rs
@@ -1,0 +1,170 @@
+//! Regression test: the transaction id Trino returns must be captured and sent
+//! on subsequent statements.
+
+use trino_rust_client::client::ClientBuilder;
+use trino_rust_client::transaction::TransactionId;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const TX_ID: &str = "17cbc429-462a-4da3-9a06-02b6507d0d01";
+
+async fn make_mock_server() -> (MockServer, String, u16) {
+    let server = MockServer::start().await;
+    let uri = server.uri();
+    let host_port = uri.trim_start_matches("http://");
+    let (host, port_str) = host_port.rsplit_once(':').unwrap();
+    let port: u16 = port_str.parse().unwrap();
+    (server, host.to_string(), port)
+}
+
+/// A statement response. `next` is the path to follow, or `None` for the final
+/// page.
+fn page(server_uri: &str, id: &str, next: Option<&str>) -> String {
+    let next_uri = match next {
+        Some(p) => format!(r#""nextUri": "{server_uri}{p}","#),
+        None => String::new(),
+    };
+    format!(
+        r#"{{
+            "id": "{id}",
+            "infoUri": "{server_uri}/ui/query.html?{id}",
+            {next_uri}
+            "stats": {{
+                "state": "FINISHED", "queued": false, "scheduled": false,
+                "nodes": 0, "totalSplits": 0, "queuedSplits": 0,
+                "runningSplits": 0, "completedSplits": 0,
+                "cpuTimeMillis": 0, "wallTimeMillis": 0, "queuedTimeMillis": 0,
+                "elapsedTimeMillis": 0, "processedRows": 0, "processedBytes": 0,
+                "peakMemoryBytes": 0, "spilledBytes": 0
+            }},
+            "warnings": []
+        }}"#
+    )
+}
+
+#[tokio::test]
+async fn transaction_id_is_captured_sent_and_cleared() {
+    let (server, host, port) = make_mock_server().await;
+    let uri = server.uri();
+
+    // 1. START TRANSACTION: the POST is accepted, and the follow-up page
+    //    carries the started-transaction header, exactly as Trino does.
+    Mock::given(method("POST"))
+        .and(path("/v1/statement"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(page(
+            &uri,
+            "q_begin",
+            Some("/v1/statement/q_begin/1"),
+        )))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/statement/q_begin/1"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("X-Trino-Started-Transaction-Id", TX_ID)
+                .set_body_string(page(&uri, "q_begin", None)),
+        )
+        .mount(&server)
+        .await;
+
+    let client = ClientBuilder::new("test_user", host)
+        .port(port)
+        .build()
+        .unwrap();
+
+    client.begin_transaction().await.expect("begin failed");
+
+    assert_eq!(
+        client.transaction_id().await,
+        TransactionId::Id(TX_ID.to_string()),
+        "the UUID from X-Trino-Started-Transaction-Id must be retained"
+    );
+
+    // 2. The next statement must carry the UUID.
+    client.execute("SELECT 1").await.expect("select failed");
+
+    let requests = server.received_requests().await.unwrap();
+    let select_request = requests
+        .iter()
+        .find(|r| r.body == b"SELECT 1")
+        .expect("no request carried the SELECT body");
+    assert_eq!(
+        select_request
+            .headers
+            .get("X-Trino-Transaction-Id")
+            .expect("X-Trino-Transaction-Id header missing")
+            .to_str()
+            .unwrap(),
+        TX_ID,
+        "statements must run inside the transaction, not with NONE"
+    );
+
+    // 3. COMMIT clears it.
+    server.reset().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/statement"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(page(
+            &uri,
+            "q_commit",
+            Some("/v1/statement/q_commit/1"),
+        )))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/v1/statement/q_commit/1"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("X-Trino-Clear-Transaction-Id", "true")
+                .set_body_string(page(&uri, "q_commit", None)),
+        )
+        .mount(&server)
+        .await;
+
+    client.commit().await.expect("commit failed");
+
+    assert_eq!(
+        client.transaction_id().await,
+        TransactionId::NoTransaction,
+        "X-Trino-Clear-Transaction-Id must reset the session"
+    );
+}
+
+#[tokio::test]
+async fn statements_send_none_when_no_transaction_is_active() {
+    let (server, host, port) = make_mock_server().await;
+    let uri = server.uri();
+
+    Mock::given(method("POST"))
+        .and(path("/v1/statement"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(page(
+            &uri,
+            "q1",
+            Some("/v1/statement/q1/1"),
+        )))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/v1/statement/q1/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(page(&uri, "q1", None)))
+        .mount(&server)
+        .await;
+
+    let client = ClientBuilder::new("test_user", host)
+        .port(port)
+        .build()
+        .unwrap();
+    client.execute("SELECT 1").await.expect("select failed");
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(
+        requests[0]
+            .headers
+            .get("X-Trino-Transaction-Id")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "NONE"
+    );
+}


### PR DESCRIPTION
## Summary

The client could start a Trino transaction but never use one. Trino returns the new transaction's identifier in `X-Trino-Started-Transaction-Id`; the client parsed that header with a function recognising only four fixed literals, so a real identifier matched none of them and was silently dropped, no log line either. Every subsequent statement then sent `X-Trino-Transaction-Id: NONE` and ran outside the transaction, and `COMMIT`/`ROLLBACK` could not address it.

- `TransactionId` now models what the header actually carries:
  `NoTransaction | Id(String)`. The three SQL-literal variants are removed, they are statements, not header values, and sending them produced a header   Trino rejects. **Breaking**; see `MIGRATION.md`.
- Parsing is infallible, so the value can no longer be silently discarded.
- New `Client::begin_transaction` / `commit` / `rollback`, plus async   `transaction_id` / `set_transaction_id` so a live client can move in and out   of a transaction.
- New `Error::Transaction` guards nesting and no-op commits locally. 
- Unparseable `X-Trino-Set-Role` values are now logged rather than dropped.

## Testing

- Unit tests for `TransactionId` parsing and the `Client` state guards.
- `tests/transaction.rs` wiremock test asserting the exact wire round-trip:
  identifier captured, sent on the next statement, cleared on commit. Verified load-bearing by reverting each half of the fix independently.
- `integration_tests/tests/transaction_test.rs` round trip against real Trino 478, run repeatedly with no flakiness.

## Known limitations

- The nesting guard is best-effort, not atomic, the session lock is released before the statement is sent, so concurrent `begin_transaction` calls on a shared client can orphan a transaction. Documented on the method; use one client per transaction.
- No test covers rollback actually discarding a write. That needs a transactional connector such as postgresql; the `memory` catalog used by theintegration suite cannot demonstrate it.