### PR TITLE
fix: error when START TRANSACTION returns no transaction id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 ## [Unreleased]
 
 ### Added
-- `Client::begin_transaction`, `Client::commit` and `Client::rollback` for driving Trino transactions, plus `Client::transaction_id` / `Client::set_transaction_id` to inspect and set the session's transaction at runtime (previously only settable at build time via `ClientBuilder::transaction_id`)
+- `Client::begin_transaction`, `Client::commit` and `Client::rollback` for driving Trino transactions, plus `Client::transaction_id` / `Client::set_transaction_id` to inspect and set the session's transaction at runtime (previously only settable at build time via `ClientBuilder::transaction_id`). `begin_transaction` verifies that the coordinator actually returned a transaction id, so `Ok(())` means a transaction is active — a `START TRANSACTION` that succeeds without a usable `X-Trino-Started-Transaction-Id` (a header-stripping proxy, or the `NONE` sentinel) is reported as `Error::Transaction` instead of silently leaving later statements outside any transaction
 - `Error::Transaction` — returned when a transaction operation is attempted in a state that does not allow it (starting one while another is active, or committing/rolling back without one)
 - `TransactionId::is_active`
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1059,10 +1059,19 @@ impl Client {
     /// Returns [`Error::Transaction`] if a transaction is already active —
     /// Trino does not support nested transactions.
     ///
-    /// On failure the transaction may nevertheless have been started, since the
-    /// identifier is captured before the statement finishes. Call
-    /// [`rollback`](Self::rollback) to discard it; that also clears an
-    /// identifier the coordinator has already expired.
+    /// Also returns [`Error::Transaction`] if the statement succeeded but no
+    /// usable identifier came back in `X-Trino-Started-Transaction-Id`. A
+    /// healthy coordinator always sends it, so this signals something between
+    /// client and coordinator dropping or rewriting the header. The
+    /// transaction may be open on the coordinator, and because its identifier
+    /// never reached the client it cannot be committed or rolled back — it
+    /// stays open until the coordinator times it out. Surfacing that as an
+    /// error is what lets `Ok(())` mean a transaction is genuinely active.
+    ///
+    /// When the statement itself fails the transaction may nevertheless have
+    /// been started, since the identifier is captured before the statement
+    /// finishes. Call [`rollback`](Self::rollback) to discard it; that also
+    /// clears an identifier the coordinator has already expired.
     pub async fn begin_transaction(&self) -> Result<()> {
         // Bind the guard to a local: holding it across `execute` would deadlock
         // against the write lock `update_session` takes.
@@ -1074,6 +1083,19 @@ impl Client {
             ));
         }
         self.execute("START TRANSACTION").await?;
+
+        // `execute` drains every page and each response passes through
+        // `update_session`, so the identifier has had every chance to arrive by
+        // now. If it still has not, the session is not in a transaction and
+        // reporting success would put every later statement back on `NONE` —
+        // the silent failure this API exists to prevent.
+        if !self.session.read().await.transaction_id.is_active() {
+            return Err(Error::Transaction(
+                "START TRANSACTION succeeded but no usable transaction id was returned in \
+                 X-Trino-Started-Transaction-Id; the session is not in a transaction"
+                    .to_string(),
+            ));
+        }
         Ok(())
     }
 
@@ -1100,6 +1122,16 @@ impl Client {
     ///
     /// Trino answers either with `X-Trino-Clear-Transaction-Id`, which
     /// `update_session` turns back into `TransactionId::NoTransaction`.
+    ///
+    /// Deliberately without the post-condition [`begin_transaction`]
+    /// (Self::begin_transaction) carries. If the clear header never arrives the
+    /// session keeps an identifier the coordinator has already retired, but
+    /// that fails loudly: the next statement sends the dead id and Trino
+    /// rejects it. The `begin_transaction` case is the dangerous one because
+    /// there the session falls back to `NONE`, which Trino happily accepts as
+    /// "no transaction" and executes outside any transaction. Callers that
+    /// need to recover here can reset the session with
+    /// [`set_transaction_id`](Self::set_transaction_id).
     async fn end_transaction(&self, statement: &str) -> Result<()> {
         let active = self.session.read().await.transaction_id.is_active();
         if !active {

--- a/tests/transaction.rs
+++ b/tests/transaction.rs
@@ -2,6 +2,7 @@
 //! on subsequent statements.
 
 use trino_rust_client::client::ClientBuilder;
+use trino_rust_client::error::Error;
 use trino_rust_client::transaction::TransactionId;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -128,6 +129,85 @@ async fn transaction_id_is_captured_sent_and_cleared() {
         client.transaction_id().await,
         TransactionId::NoTransaction,
         "X-Trino-Clear-Transaction-Id must reset the session"
+    );
+}
+
+/// Mount a `START TRANSACTION` exchange whose final page carries `header`
+/// (or no started-transaction header at all when `header` is `None`).
+async fn mount_begin(server: &MockServer, header: Option<&str>) {
+    let uri = server.uri();
+
+    Mock::given(method("POST"))
+        .and(path("/v1/statement"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(page(
+            &uri,
+            "q_begin",
+            Some("/v1/statement/q_begin/1"),
+        )))
+        .mount(server)
+        .await;
+
+    let mut final_page = ResponseTemplate::new(200).set_body_string(page(&uri, "q_begin", None));
+    if let Some(value) = header {
+        final_page = final_page.insert_header("X-Trino-Started-Transaction-Id", value);
+    }
+    Mock::given(method("GET"))
+        .and(path("/v1/statement/q_begin/1"))
+        .respond_with(final_page)
+        .mount(server)
+        .await;
+}
+
+/// A coordinator that accepts `START TRANSACTION` but never returns the
+/// identifier (a header-stripping proxy, say) must not leave the caller
+/// believing a transaction is open — otherwise every later statement silently
+/// runs with `NONE`, which is the very failure this API exists to prevent.
+#[tokio::test]
+async fn begin_transaction_fails_when_no_id_is_returned() {
+    let (server, host, port) = make_mock_server().await;
+    mount_begin(&server, None).await;
+
+    let client = ClientBuilder::new("test_user", host)
+        .port(port)
+        .build()
+        .unwrap();
+
+    let err = client
+        .begin_transaction()
+        .await
+        .expect_err("begin_transaction must not report success without a transaction id");
+
+    assert!(
+        matches!(err, Error::Transaction(_)),
+        "expected Error::Transaction, got {err:?}"
+    );
+    assert_eq!(
+        client.transaction_id().await,
+        TransactionId::NoTransaction,
+        "the session must stay out of a transaction"
+    );
+}
+
+/// Same contract when the header arrives but carries the `NONE` sentinel,
+/// which parses back to `TransactionId::NoTransaction`.
+#[tokio::test]
+async fn begin_transaction_fails_when_id_is_the_none_sentinel() {
+    let (server, host, port) = make_mock_server().await;
+    mount_begin(&server, Some("NONE")).await;
+
+    let client = ClientBuilder::new("test_user", host)
+        .port(port)
+        .build()
+        .unwrap();
+
+    let err = client
+        .begin_transaction()
+        .await
+        .expect_err("begin_transaction must not report success on the NONE sentinel");
+
+    assert!(
+        matches!(err, Error::Transaction(_)),
+        "expected Error::Transaction, got {err:?}"
     );
 }
 


### PR DESCRIPTION
## Description

Follow-up to #62, from review feedback on that PR.

## Problem

`begin_transaction` returned `Ok(())` as soon as `START TRANSACTION` succeeded,
without checking that the session had actually captured an identifier.

`update_session` is the only writer of `transaction_id`, and it is a no-op when
`X-Trino-Started-Transaction-Id` is:

- absent entirely (a proxy or gateway that strips unknown headers),
- unparseable — `to_str()` fails on a non-ASCII value, which is only `warn!`ed,
- the literal `NONE`, which `TransactionId::from_header_value` maps back to
  `NoTransaction`.

In all three cases the caller was told the transaction was open while the session
stayed on `NoTransaction`, so every subsequent statement silently sent
`X-Trino-Transaction-Id: NONE` and ran outside any transaction.

That is precisely the failure mode #62 set out to eliminate, one layer up: there
the identifier was discarded after arriving, here it never arrives at all. The
symptom — writes silently landing outside the transaction — is identical.

## Change

A post-condition in `begin_transaction`, placed after `execute()`. `execute`
drains every page and each response passes through `update_session`, so the
header has had every opportunity to arrive by that point:

```rust
if !self.session.read().await.transaction_id.is_active() {
    return Err(Error::Transaction(
        "START TRANSACTION succeeded but no usable transaction id was returned in
         X-Trino-Started-Transaction-Id; the session is not in a transaction".to_string(),
    ));
}
```

Ok(()) now means a transaction is genuinely active.

end_transaction is deliberately left alone

It has the mirror gap — a missing X-Trino-Clear-Transaction-Id leaves a retired
identifier in the session — but that fails loudly: the next statement sends the
dead id and Trino rejects it. begin_transaction was the dangerous one precisely
because its failure mode degrades to NONE, which Trino accepts as valid and
executes against. Documented inline so the asymmetry is intentional rather than
oversight.

Notes

- A healthy coordinator always sends the header, so this only fires on a broken
network path. It is a diagnostic, not a routine code path.
- When it does fire, the transaction may be open on the coordinator and cannot
be recovered — its identifier never reached the client, so it can be neither
committed nor rolled back, and stays open until the coordinator times it out.
Still strictly better than silently running non-transactional writes.
- This also corrects the existing # Errors doc, which advised calling rollback
to discard a partially-started transaction. That advice is right for a failed
statement but wrong for this new error, where there is no id to roll back.