### PR TITLE
feat: selectable rustls crypto provider

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -34,7 +34,8 @@ git checkout -b release/X.Y.Z
 - Finalize `CHANGELOG.md`: turn `## [Unreleased]` into `## [X.Y.Z] - <date>`
   (leave an empty `[Unreleased]` above it) and add the comparison link at the
   bottom (**no `v` prefix** — tags are `X.Y.Z`, e.g. `compare/0.10.0...0.11.0`).
-- Update the version in `README.md` install snippets (there are two).
+- Update the version in `README.md` install snippets (there are three: two
+  under Installation, one under TLS provider).
 - If the release has breaking changes, make sure `MIGRATION.md` covers them.
 - `cargo check` and `cargo check --features spooling`.
 - Commit `release X.Y.Z`, push the branch, open a PR.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,46 @@ jobs:
       - name: Run integration tests
         run: cargo test --package trino-integration-tests
 
+  tls_features:
+    name: TLS backend features
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
+        rust: [stable, nightly]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install latest ${{ matrix.rust }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+
+      - name: Run cargo test (bring-your-own provider)
+        run: cargo test --no-default-features --features rustls-no-provider --workspace --exclude trino-integration-tests
+
+      - name: Run cargo test (ring provider)
+        run: cargo test --no-default-features --features rustls-ring,spooling --workspace --exclude trino-integration-tests
+
+      # One step per configuration: `!`-negated commands are exempt from
+      # `set -e`, so chaining them in a single script would mask a failure.
+      - name: aws-lc-rs must be out of the rustls-no-provider graph
+        run: |
+          cargo tree --no-default-features --features rustls-no-provider > tree.txt
+          ! grep -q aws-lc tree.txt
+
+      - name: aws-lc-rs must be out of the rustls-ring graph
+        run: |
+          cargo tree --no-default-features --features rustls-ring > tree.txt
+          ! grep -q aws-lc tree.txt
+
+      - name: A build with no TLS backend must fail on the feature check
+        run: |
+          ! cargo check --no-default-features 2> check.log
+          grep -q "needs a TLS backend feature" check.log
+
   msrv:
     name: Minimum supported Rust version
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## [Unreleased]
 
+### Added
+- Selectable rustls crypto provider through cargo features: `rustls-aws-lc-rs` (default, unchanged behaviour), `rustls-ring` and `rustls-no-provider`. `reqwest`'s `rustls` feature hardwires `aws-lc-rs`, and because cargo features are additive there was no way for a dependent to opt out of the heavy `aws-lc-sys` C build. With `default-features = false, features = ["rustls-ring"]` (or `rustls-no-provider` plus your own `CryptoProvider`), `aws-lc-rs` no longer enters the dependency graph [#70](https://github.com/nudibranches-tech/trino-rust-client/issues/70)
+- Under `rustls-ring`, `ClientBuilder::build` installs `ring` as the process default rustls provider when none is installed yet, so nothing has to be set up in `main`. A bare `rustls-no-provider` build leaves that to the caller — `reqwest` panics while building its client if no provider is installed
+
+### Changed
+- **Breaking:** the crate's default features now include `rustls-aws-lc-rs`, and a build with no TLS backend feature fails with a `compile_error!`. `default-features = false` previously still got rustls with `aws-lc-rs` (the feature was hardwired on the `reqwest` dependency); it now has to name a TLS backend feature. See the [migration guide](MIGRATION.md)
+- `Client::execute` makes one HTTP request fewer: the final page is read from its pagination loop instead of being re-fetched
+
 ### Fixed
 - **`Client::execute` bypassed authentication on its final result fetch.** It ended by re-fetching the last page with a bare GET that skipped the shared request pipeline, so the request carried no `Authorization` (for any `Auth` variant), `X-Trino-User` or `User-Agent`, and got neither the `RetryPolicy` nor the OAuth2 `401`-challenge retry. `execute` therefore failed against any authenticated coordinator — as a misleading `Error::HttpError("error decoding response body")` rather than `Error::HttpNotOk`, and only after the statement had run — while `get_all` / `stream` succeeded on the same client. It now reports the last page of its own pagination loop
 - `Client::execute` no longer returns `Error::InternalError("No next URI available for execution result")` when the first response carries no `next_uri`
-
-### Changed
-- `Client::execute` makes one HTTP request fewer: the final page is read from its pagination loop instead of being re-fetched
 
 ### Deprecated
 - `error::TrinoRetryResult` and `error::TrinoStats` — unused, still `pub` (so not a breaking change), removal planned for the next major release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,22 @@ Always verify **both** feature configurations (`default` and `spooling`). The
 `spooling` codec dependencies are gated behind the feature; `base64` is a core
 dependency (needed by `VarBinary`).
 
+The TLS backend is a feature too (`rustls-aws-lc-rs` — default, `rustls-ring`,
+`rustls-no-provider`; one is required, see `src/tls.rs`), so changes touching
+`reqwest`, `ssl.rs` or `ClientBuilder::build` should also check:
+
+```bash
+cargo test --no-default-features --features rustls-no-provider \
+    --workspace --exclude trino-integration-tests
+cargo test --no-default-features --features rustls-ring,spooling \
+    --workspace --exclude trino-integration-tests
+```
+
+Building a client needs a crypto provider, and a bare `rustls-no-provider`
+build has none (`reqwest` panics). Tests that build one are gated on
+`#[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]` — the two
+backends that carry a provider. Gate new ones the same way.
+
 ## Workflow
 
 - **Never commit directly to `main`.** Pre-commit hooks (`.pre-commit-config.yaml`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ paste = {workspace = true}
 regex = {workspace = true}
 # network dependencies
 reqwest = {workspace = true}
+rustls = {workspace = true, optional = true}
 # third party dependencies
 serde = {workspace = true}
 serde_json = {workspace = true}
@@ -44,7 +45,16 @@ path = "examples/spooling.rs"
 required-features = ["spooling"]
 
 [features]
-default = []
+default = ["rustls-aws-lc-rs"]
+# TLS backend. Exactly one provider is needed; the default keeps the historical
+# behaviour (reqwest's `rustls` feature, backed by `aws-lc-rs`).
+rustls-aws-lc-rs = ["reqwest/rustls"]
+# rustls without a built-in provider: install a `CryptoProvider` yourself before
+# building a `Client`.
+rustls-no-provider = ["reqwest/rustls-no-provider"]
+# `rustls-no-provider` plus `ring`, installed as the process default provider on
+# the first `ClientBuilder::build` if none is installed yet.
+rustls-ring = ["dep:rustls", "rustls-no-provider", "rustls/ring"]
 spooling = ["dep:zstd", "dep:lz4", "dep:flate2"]
 
 [package]
@@ -90,7 +100,11 @@ lz4 = "1.28"
 open = "5"
 paste = "1.0.15"
 regex = "1.13.1"
-reqwest = {version = "0.13.4", default-features = false, features = ["rustls", "json"]}
+reqwest = {version = "0.13.4", default-features = false, features = ["json"]}
+# Direct dependency only so `rustls-ring` can install `ring` as the process
+# default provider. Provider-free on purpose: rustls's default features would
+# pull `aws-lc-rs` back in.
+rustls = {version = "0.23.4", default-features = false, features = ["std"]}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0.150"
 thiserror = "2.0.18"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,17 @@
 Guidance for upgrading across breaking releases. See [CHANGELOG.md](CHANGELOG.md)
 for the full list of changes.
 
+## Unreleased
+
+### `default-features = false` now needs a TLS backend feature
+
+The rustls crypto provider is selectable: `rustls-aws-lc-rs` (default),
+`rustls-ring` or `rustls-no-provider`. Builds with default features are
+unaffected. Builds with `default-features = false` used to get `aws-lc-rs`
+anyway and now have to add one of those features — `rustls-aws-lc-rs` to keep
+the same backend, `rustls-ring` to drop the `aws-lc-sys` C build. See the
+[README](README.md#tls-provider) for the feature matrix.
+
 ## 0.11.0 → 0.12.0
 
 ### Transactions (`TransactionId` reshaped)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Fork rationale  :
 ### protocols:
 - Spooling Protocol (for efficient large result set handling)
 
+### tls:
+- Selectable rustls crypto provider (`aws-lc-rs`, `ring`, or bring your own)
+
 ## Installation
 
 ```toml
@@ -29,6 +32,47 @@ trino-rust-client = "0.12.0"
 
 # For spooling protocol support
 trino-rust-client = { version = "0.12.0", features = ["spooling"] }
+```
+
+### TLS provider
+
+HTTPS goes through [rustls](https://docs.rs/rustls); the cryptographic provider
+behind it is picked with a cargo feature. One of them is required — a build with
+none fails with a `compile_error!`.
+
+| feature | provider | setup |
+| --- | --- | --- |
+| `rustls-aws-lc-rs` *(default)* | `aws-lc-rs` | none |
+| `rustls-ring` | `ring` | none — installed as the process default provider on the first `ClientBuilder::build`, unless one is already installed |
+| `rustls-no-provider` | yours | install a `CryptoProvider` before building a client — `reqwest` panics without one |
+
+`aws-lc-rs` pulls in `aws-lc-sys`. To leave it out, turn the default feature off
+and pick another provider:
+
+```toml
+[dependencies]
+trino-rust-client = { version = "0.12.0", default-features = false, features = ["rustls-ring"] }
+```
+
+Turning the default feature off only pays off if nothing else in the graph
+enables it: with both features on you get `aws-lc-sys` compiled *and* `ring`
+installed as the process default provider, so the C build stays and `ring` is
+what `reqwest` ends up using.
+
+With `rustls-no-provider`, install the provider yourself before any client is
+built. Depend on the same rustls major as `reqwest` (`0.23`), otherwise the
+provider you install is not the one `reqwest` reads:
+
+```toml
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+```
+
+```rust
+rustls::crypto::ring::default_provider()
+    .install_default()
+    .expect("install rustls crypto provider");
+
+let client = ClientBuilder::new("user", "localhost").build()?;
 ```
 
 ## Upgrading

--- a/src/auth/oauth2.rs
+++ b/src/auth/oauth2.rs
@@ -242,9 +242,11 @@ mod tests {
         assert_eq!(state.cached_token().as_deref(), Some("tok"));
     }
 
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     struct RecordingHandler {
         seen: std::sync::Mutex<Vec<String>>,
     }
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     impl RedirectHandler for RecordingHandler {
         fn redirect(&self, url: &str) -> Result<()> {
             self.seen.lock().unwrap().push(url.to_string());
@@ -252,6 +254,7 @@ mod tests {
         }
     }
 
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     #[tokio::test]
     async fn run_flow_follows_next_uri_then_returns_token() {
         use wiremock::matchers::{method, path};
@@ -295,6 +298,7 @@ mod tests {
         );
     }
 
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     #[tokio::test]
     async fn run_flow_surfaces_error_field() {
         use wiremock::matchers::{method, path};
@@ -328,6 +332,7 @@ mod tests {
         }
     }
 
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     #[tokio::test]
     async fn run_flow_bounded_by_poll_timeout_when_server_stalls() {
         use wiremock::matchers::{method, path};

--- a/src/auth/oauth2.rs
+++ b/src/auth/oauth2.rs
@@ -242,9 +242,22 @@ mod tests {
         assert_eq!(state.cached_token().as_deref(), Some("tok"));
     }
 
+    /// A client for the flow under test.
+    ///
+    /// `reqwest::Client::new()` panics under `rustls-ring` unless a crypto
+    /// provider is installed, and here nothing else in the process has
+    /// necessarily built one yet.
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+    fn test_http_client() -> reqwest::Client {
+        crate::tls::prepare_crypto_provider();
+        reqwest::Client::new()
+    }
+
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     struct RecordingHandler {
         seen: std::sync::Mutex<Vec<String>>,
     }
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     impl RedirectHandler for RecordingHandler {
         fn redirect(&self, url: &str) -> Result<()> {
             self.seen.lock().unwrap().push(url.to_string());
@@ -252,6 +265,7 @@ mod tests {
         }
     }
 
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     #[tokio::test]
     async fn run_flow_follows_next_uri_then_returns_token() {
         use wiremock::matchers::{method, path};
@@ -284,7 +298,7 @@ mod tests {
             x_token_server: format!("{}/token/step1", server.uri()),
         };
 
-        let token = run_flow(&reqwest::Client::new(), &state, &challenge)
+        let token = run_flow(&test_http_client(), &state, &challenge)
             .await
             .expect("flow should succeed");
 
@@ -295,6 +309,7 @@ mod tests {
         );
     }
 
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     #[tokio::test]
     async fn run_flow_surfaces_error_field() {
         use wiremock::matchers::{method, path};
@@ -319,7 +334,7 @@ mod tests {
             x_token_server: format!("{}/token/err", server.uri()),
         };
 
-        let err = run_flow(&reqwest::Client::new(), &state, &challenge)
+        let err = run_flow(&test_http_client(), &state, &challenge)
             .await
             .unwrap_err();
         match err {
@@ -328,6 +343,7 @@ mod tests {
         }
     }
 
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     #[tokio::test]
     async fn run_flow_bounded_by_poll_timeout_when_server_stalls() {
         use wiremock::matchers::{method, path};
@@ -354,7 +370,7 @@ mod tests {
             x_token_server: format!("{}/token/stall", server.uri()),
         };
 
-        let err = run_flow(&reqwest::Client::new(), &state, &challenge)
+        let err = run_flow(&test_http_client(), &state, &challenge)
             .await
             .unwrap_err();
         match err {

--- a/src/client.rs
+++ b/src/client.rs
@@ -296,6 +296,8 @@ impl ClientBuilder {
     }
 
     pub fn build(self) -> Result<Client> {
+        crate::tls::prepare_crypto_provider();
+
         let session = self.session.build()?;
         let retry = self.retry.clone();
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1400,10 +1400,20 @@ mod tests {
     use http::StatusCode;
     use reqwest::header::HeaderValue;
 
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     use super::*;
     use crate::client::{decode_kv_from_header, need_retry_fetch, need_retry_submit};
     use crate::error::Error;
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     use crate::transaction::TransactionId;
+
+    /// The selected TLS backend carries (or installs) a rustls crypto provider,
+    /// so building a client works with no setup from the caller.
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+    #[test]
+    fn test_build_with_provided_tls_backend() {
+        assert!(ClientBuilder::new("user", "localhost").build().is_ok());
+    }
 
     #[test]
     fn test_decode_kv_from_header_plus_sign_to_space() {
@@ -1469,12 +1479,16 @@ mod tests {
         )));
     }
 
+    // Building a client needs a rustls crypto provider.
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     #[tokio::test]
     async fn transaction_id_defaults_to_no_transaction() {
         let client = ClientBuilder::new("user", "localhost").build().unwrap();
         assert_eq!(client.transaction_id().await, TransactionId::NoTransaction);
     }
 
+    // Building a client needs a rustls crypto provider.
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     #[tokio::test]
     async fn set_transaction_id_is_observable() {
         let client = ClientBuilder::new("user", "localhost").build().unwrap();
@@ -1483,6 +1497,8 @@ mod tests {
         assert_eq!(client.transaction_id().await, id);
     }
 
+    // Building a client needs a rustls crypto provider.
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     #[tokio::test]
     async fn begin_transaction_rejects_nesting() {
         let client = ClientBuilder::new("user", "localhost").build().unwrap();
@@ -1497,6 +1513,8 @@ mod tests {
         );
     }
 
+    // Building a client needs a rustls crypto provider.
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     #[tokio::test]
     async fn commit_without_transaction_is_rejected() {
         let client = ClientBuilder::new("user", "localhost").build().unwrap();
@@ -1507,6 +1525,8 @@ mod tests {
         );
     }
 
+    // Building a client needs a rustls crypto provider.
+    #[cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
     #[tokio::test]
     async fn rollback_without_transaction_is_rejected() {
         let client = ClientBuilder::new("user", "localhost").build().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,34 @@
 //!   [`ClientBuilder::spooling_encoding`](client::ClientBuilder::spooling_encoding)
 //!   and related options.
 //!
+//! ## TLS backend
+//!
+//! HTTPS goes through [`rustls`](https://docs.rs/rustls); which cryptographic
+//! provider backs it is selected by feature. One of these is required.
+//!
+//! - `rustls-aws-lc-rs` *(default)* — rustls with the `aws-lc-rs` provider.
+//!   Nothing to set up, but `aws-lc-sys` is a heavy C build.
+//! - `rustls-no-provider` — rustls with no provider. Install a
+//!   [`CryptoProvider`](https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html)
+//!   before building a [`Client`]; `reqwest` panics while building its own
+//!   client if none is installed.
+//!
+//!   ```rust,ignore
+//!   rustls::crypto::ring::default_provider()
+//!       .install_default()
+//!       .expect("install rustls crypto provider");
+//!   ```
+//!
+//! - `rustls-ring` — `rustls-no-provider` plus `ring`, which
+//!   [`ClientBuilder::build`] installs as the process default provider if none
+//!   is installed yet. Avoids `aws-lc-sys` without any setup in `main`.
+//!
+//! To drop `aws-lc-rs` from the build, turn the default feature off:
+//!
+//! ```toml
+//! trino-rust-client = { default-features = false, features = ["rustls-ring"] }
+//! ```
+//!
 //! # Observability
 //!
 //! The client emits [`tracing`](https://docs.rs/tracing) events and wraps each
@@ -72,6 +100,12 @@
 //! [mg]: https://github.com/nudibranches-tech/trino-rust-client/blob/main/MIGRATION.md
 #![allow(clippy::should_implement_trait)]
 #![allow(clippy::derivable_impls)]
+
+#[cfg(not(any(feature = "rustls-aws-lc-rs", feature = "rustls-no-provider")))]
+compile_error!(
+    "trino-rust-client needs a TLS backend feature: enable `rustls-aws-lc-rs` (the default), \
+     `rustls-ring`, or `rustls-no-provider` and install a rustls CryptoProvider yourself."
+);
 
 pub mod auth;
 pub mod client;
@@ -86,6 +120,7 @@ pub mod retry;
 pub mod selected_role;
 pub mod session;
 pub mod ssl;
+mod tls;
 pub mod transaction;
 pub mod tuples;
 pub mod types;

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,0 +1,22 @@
+//! TLS backend plumbing.
+//!
+//! The TLS provider is selected with cargo features (see the crate-level
+//! documentation). Everything here is a no-op unless `rustls-ring` is enabled:
+//! that backend takes rustls without a built-in provider, so `ring` has to be
+//! installed in the process before a `reqwest::Client` is built.
+
+/// Install `ring` as the process-wide default rustls provider, unless one is
+/// already installed.
+#[cfg(feature = "rustls-ring")]
+pub(crate) fn prepare_crypto_provider() {
+    if rustls::crypto::CryptoProvider::get_default().is_none() {
+        // Racing installs are fine: exactly one wins and the loser gets an
+        // `Err` back, by which point a provider is installed either way.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+}
+
+/// Nothing to prepare: `rustls-aws-lc-rs` carries its own provider, and under a
+/// bare `rustls-no-provider` build installing one is the caller's job.
+#[cfg(not(feature = "rustls-ring"))]
+pub(crate) fn prepare_crypto_provider() {}

--- a/tests/execute.rs
+++ b/tests/execute.rs
@@ -2,6 +2,11 @@
 //! GET that skipped the client's request pipeline, and with it the auth
 //! headers and the response status check.
 
+// Every test here builds a client, which needs a rustls crypto provider — a
+// bring-your-own-provider build (`rustls-no-provider` without `rustls-ring`)
+// has none.
+#![cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+
 use trino_rust_client::auth::Auth;
 use trino_rust_client::client::ClientBuilder;
 use trino_rust_client::error::Error;

--- a/tests/get_all_empty.rs
+++ b/tests/get_all_empty.rs
@@ -1,3 +1,8 @@
+// Every test here builds a client, which needs a rustls crypto provider — a
+// bring-your-own-provider build (`rustls-no-provider` without `rustls-ring`)
+// has none.
+#![cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+
 use std::fs;
 
 use trino_rust_client::{client::ClientBuilder, Row, Trino};

--- a/tests/oauth2.rs
+++ b/tests/oauth2.rs
@@ -1,3 +1,8 @@
+// Every test here builds a client, which needs a rustls crypto provider — a
+// bring-your-own-provider build (`rustls-no-provider` without `rustls-ring`)
+// has none.
+#![cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 

--- a/tests/retry.rs
+++ b/tests/retry.rs
@@ -1,3 +1,8 @@
+// Every test here builds a client, which needs a rustls crypto provider — a
+// bring-your-own-provider build (`rustls-no-provider` without `rustls-ring`)
+// has none.
+#![cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+
 use std::fs;
 use std::time::Duration;
 

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -1,3 +1,8 @@
+// Every test here builds a client, which needs a rustls crypto provider — a
+// bring-your-own-provider build (`rustls-no-provider` without `rustls-ring`)
+// has none.
+#![cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+
 use std::fs;
 
 use futures::StreamExt;

--- a/tests/transaction.rs
+++ b/tests/transaction.rs
@@ -1,6 +1,11 @@
 //! Regression test: the transaction id Trino returns must be captured and sent
 //! on subsequent statements.
 
+// Every test here builds a client, which needs a rustls crypto provider — a
+// bring-your-own-provider build (`rustls-no-provider` without `rustls-ring`)
+// has none.
+#![cfg(any(feature = "rustls-aws-lc-rs", feature = "rustls-ring"))]
+
 use trino_rust_client::client::ClientBuilder;
 use trino_rust_client::error::Error;
 use trino_rust_client::transaction::TransactionId;


### PR DESCRIPTION
reqwest's `rustls` feature hardwires the aws-lc-rs provider, and since cargo features are additive there was no way for a dependent to opt out of the heavy `aws-lc-sys` C build — not even with `default-features = false`, because the feature sat on the `reqwest` dependency rather than behind a feature of this crate.

Move the TLS backend behind features:

- `rustls-aws-lc-rs` (default) — today's behaviour, unchanged.
- `rustls-no-provider` — rustls with no provider; the caller installs a `CryptoProvider` before building a client. If none is installed, `reqwest` panics while building its own client, with a message naming the feature and showing `install_default()`. This crate does not pre-check: whether a provider is needed is decided by reqwest's own cfg, which we cannot observe (see the review thread), so a check would reject configurations that work.
- `rustls-ring` — `rustls-no-provider` plus `ring`, installed as the process default provider on the first `ClientBuilder::build` unless one is already installed. The only backend needing a direct rustls dependency.

A build with no backend fails with a `compile_error!` naming the options. With `default-features = false` and either non-default backend, `aws-lc-rs` no longer appears in the dependency graph, which CI asserts against `cargo tree`.

Breaking for `default-features = false` users: they used to get rustls with aws-lc-rs anyway and now have to name a backend. Marked **Breaking:** in the CHANGELOG with a MIGRATION note, for 0.13.0.

Three commits for review: the change, the tests and CI, then the docs.

Closes #70
