### PR TITLE
fix: execute bypassed authentication on its final result fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## [Unreleased]
 
+### Fixed
+- **`Client::execute` bypassed authentication on its final result fetch.** It ended by re-fetching the last page with a bare GET that skipped the shared request pipeline, so the request carried no `Authorization` (for any `Auth` variant), `X-Trino-User` or `User-Agent`, and got neither the `RetryPolicy` nor the OAuth2 `401`-challenge retry. `execute` therefore failed against any authenticated coordinator — as a misleading `Error::HttpError("error decoding response body")` rather than `Error::HttpNotOk`, and only after the statement had run — while `get_all` / `stream` succeeded on the same client. It now reports the last page of its own pagination loop
+- `Client::execute` no longer returns `Error::InternalError("No next URI available for execution result")` when the first response carries no `next_uri`
+
+### Changed
+- `Client::execute` makes one HTTP request fewer: the final page is read from its pagination loop instead of being re-fetched
+
+### Deprecated
+- `error::TrinoRetryResult` and `error::TrinoStats` — unused, still `pub` (so not a breaking change), removal planned for the next major release
+
 ## [0.12.0] - 2026-08-19
 
 > Upgrading from 0.11.x? See the [migration guide](MIGRATION.md).

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,7 +16,6 @@ use tracing::*;
 
 use crate::auth::Auth;
 use crate::build_dataset;
-use crate::error::TrinoRetryResult;
 use crate::error::{Error, Result};
 use crate::header::*;
 use crate::models::Column;
@@ -989,41 +988,23 @@ impl Client {
     #[tracing::instrument(skip_all, fields(query_id = tracing::field::Empty))]
     pub async fn execute(&self, sql: impl Into<String>) -> Result<ExecuteResult> {
         // try the sql first
-        let res = self.get_retry::<Row>(sql.into()).await?;
+        let mut res = self.get_retry::<Row>(sql.into()).await?;
         tracing::Span::current().record("query_id", res.id.as_str());
 
-        let mut next = res.next_uri;
-        let mut final_uri = next.clone();
-
         // Trino attempts several times to execute a query before marking it as failed.
-        // At the end, retrieve the URL of the last request to get the result
-        while let Some(url) = &next {
-            let res = self.get_next_retry::<Row>(url).await?;
-
-            let next_uri = res.next_uri;
-
-            // If next_uri is not None, update final_uri
-            if next_uri.is_some() {
-                final_uri = next_uri.clone();
-            }
-            next = next_uri;
+        // At the end, the last response holds the result
+        while let Some(url) = res.next_uri.take() {
+            res = self.get_next_retry::<Row>(&url).await?;
         }
 
-        let url = final_uri.ok_or_else(|| {
-            Error::InternalError("No next URI available for execution result".to_string())
-        })?;
-
-        // Parse the final URI to get TrinoRetryResult
-        let result = self.try_get_retry_result(&url).await?;
-
-        if let Some(error) = result.error {
+        if let Some(error) = res.error {
             return Err(error.into());
         }
 
         Ok(ExecuteResult {
             output_uri: None,
-            update_type: result.update_type,
-            update_count: result.update_count,
+            update_type: res.update_type,
+            update_count: res.update_count,
         })
     }
 
@@ -1151,14 +1132,6 @@ impl Client {
         }
         self.execute(statement).await?;
         Ok(())
-    }
-
-    async fn try_get_retry_result(&self, url: &str) -> Result<TrinoRetryResult> {
-        let response = self.client.get(url).send().await?;
-
-        let result = response.json::<TrinoRetryResult>().await?;
-
-        Ok(result)
     }
 
     fn retry_policy(&self) -> ExponentialBuilder {

--- a/src/error.rs
+++ b/src/error.rs
@@ -78,6 +78,13 @@ impl From<QueryError> for Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Unused since [`Client::execute`](crate::client::Client::execute) stopped
+/// re-fetching the page its pagination loop had already read.
+#[allow(deprecated)] // for the `stats` field below
+#[deprecated(
+    note = "unused; `Client::execute` reports the last `QueryResult` of its pagination loop. \
+            Scheduled for removal in the next major release."
+)]
 #[derive(Debug, Deserialize)]
 pub struct TrinoRetryResult {
     pub id: String,
@@ -91,6 +98,10 @@ pub struct TrinoRetryResult {
     pub update_count: Option<u64>,
 }
 
+/// The `stats` of a [`TrinoRetryResult`].
+#[deprecated(
+    note = "unused, alongside `TrinoRetryResult`. Scheduled for removal in the next major release."
+)]
 #[derive(Debug, Deserialize)]
 pub struct TrinoStats {
     pub state: String,

--- a/tests/execute.rs
+++ b/tests/execute.rs
@@ -1,0 +1,188 @@
+//! Regression tests: `execute` used to fetch its final result page with a bare
+//! GET that skipped the client's request pipeline, and with it the auth
+//! headers and the response status check.
+
+use trino_rust_client::auth::Auth;
+use trino_rust_client::client::ClientBuilder;
+use trino_rust_client::error::Error;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+/// `alice:alice`, as `reqwest` encodes it.
+const BASIC_AUTH: &str = "Basic YWxpY2U6YWxpY2U=";
+
+async fn make_mock_server() -> (MockServer, String, u16) {
+    let server = MockServer::start().await;
+    let uri = server.uri();
+    let host_port = uri.trim_start_matches("http://");
+    let (host, port_str) = host_port.rsplit_once(':').unwrap();
+    let port: u16 = port_str.parse().unwrap();
+    (server, host.to_string(), port)
+}
+
+/// `next` is the path to follow, or `None` for the final page.
+fn page(server_uri: &str, id: &str, next: Option<&str>) -> String {
+    let next_uri = match next {
+        Some(p) => format!(r#""nextUri": "{server_uri}{p}","#),
+        None => String::new(),
+    };
+    format!(
+        r#"{{
+            "id": "{id}",
+            "infoUri": "{server_uri}/ui/query.html?{id}",
+            {next_uri}
+            "stats": {{
+                "state": "FINISHED", "queued": false, "scheduled": false,
+                "nodes": 0, "totalSplits": 0, "queuedSplits": 0,
+                "runningSplits": 0, "completedSplits": 0,
+                "cpuTimeMillis": 0, "wallTimeMillis": 0, "queuedTimeMillis": 0,
+                "elapsedTimeMillis": 0, "processedRows": 0, "processedBytes": 0,
+                "peakMemoryBytes": 0, "spilledBytes": 0
+            }},
+            "warnings": [],
+            "updateType": "CREATE TABLE"
+        }}"#
+    )
+}
+
+fn header_value(req: &Request, name: &str) -> Option<String> {
+    req.headers
+        .get(name)
+        .map(|v| v.to_str().unwrap().to_string())
+}
+
+async fn mount_authenticated_statement_mocks(server: &MockServer) {
+    let uri = server.uri();
+
+    Mock::given(method("POST"))
+        .and(path("/v1/statement"))
+        .and(header("Authorization", BASIC_AUTH))
+        .respond_with(ResponseTemplate::new(200).set_body_string(page(
+            &uri,
+            "test_execute_00001",
+            Some("/v1/statement/test_execute_00001/1"),
+        )))
+        .expect(1)
+        .with_priority(1)
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/statement/test_execute_00001/1"))
+        .and(header("Authorization", BASIC_AUTH))
+        .respond_with(ResponseTemplate::new(200).set_body_string(page(
+            &uri,
+            "test_execute_00001",
+            None,
+        )))
+        .expect(1)
+        .with_priority(1)
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(401)
+                .insert_header("WWW-Authenticate", r#"Basic realm="Trino""#)
+                .set_body_string("<html><body>Unauthorized</body></html>"),
+        )
+        .expect(0)
+        .with_priority(10)
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn test_execute_authenticates_every_request() {
+    let (server, host, port) = make_mock_server().await;
+    mount_authenticated_statement_mocks(&server).await;
+
+    let client = ClientBuilder::new("alice", host)
+        .port(port)
+        .auth(Auth::new_basic("alice", Some("alice")))
+        // Lifts the "no basic auth over http" guard, for the mock server.
+        .auth_http_insecure(true)
+        .build()
+        .unwrap();
+
+    let result = client
+        .execute("CREATE TABLE IF NOT EXISTS t (a integer)")
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "every request execute makes must go through the authenticated path, got: {:?}",
+        result.err()
+    );
+    assert_eq!(result.unwrap().update_type.as_deref(), Some("CREATE TABLE"));
+
+    for req in server.received_requests().await.unwrap() {
+        let at = format!("{} {}", req.method, req.url.path());
+        assert_eq!(
+            header_value(&req, "Authorization").as_deref(),
+            Some(BASIC_AUTH),
+            "{at} went out unauthenticated"
+        );
+        assert_eq!(
+            header_value(&req, "X-Trino-User").as_deref(),
+            Some("alice"),
+            "{at} is missing X-Trino-User"
+        );
+        assert_eq!(
+            header_value(&req, "User-Agent").as_deref(),
+            Some("trino-rust-client"),
+            "{at} is missing the client's User-Agent"
+        );
+    }
+
+    // Each page fetched exactly once: no second fetch of the final page.
+    server.verify().await;
+}
+
+/// A rejected fetch used to be deserialized without a status check, surfacing
+/// as `HttpError(Decode)` rather than as the status Trino returned.
+#[tokio::test]
+async fn test_execute_reports_a_rejected_page_fetch_as_http_not_ok() {
+    let (server, host, port) = make_mock_server().await;
+    let uri = server.uri();
+
+    Mock::given(method("POST"))
+        .and(path("/v1/statement"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(page(
+            &uri,
+            "test_execute_00002",
+            Some("/v1/statement/test_execute_00002/1"),
+        )))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/statement/test_execute_00002/1"))
+        .respond_with(
+            ResponseTemplate::new(401)
+                .insert_header("WWW-Authenticate", r#"Basic realm="Trino""#)
+                .set_body_string("<html><body>Unauthorized</body></html>"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let err = ClientBuilder::new("alice", host)
+        .port(port)
+        .build()
+        .unwrap()
+        .execute("CREATE TABLE IF NOT EXISTS t (a integer)")
+        .await
+        .expect_err("a 401 must not be reported as success");
+
+    match err {
+        Error::HttpNotOk(status, body) => {
+            assert_eq!(status, 401);
+            assert!(body.contains("Unauthorized"), "body was: {body}");
+        }
+        other => panic!("expected Error::HttpNotOk, got: {other:?}"),
+    }
+
+    server.verify().await;
+}


### PR DESCRIPTION
Closes #68.

`Client::execute` ended by re-fetching its last result page with a bare `reqwest` GET — the
only request in the client that skipped the shared `add_prepare_header` + `send` pipeline. It
went out with no `Authorization` (for any `Auth` variant), no `X-Trino-User` and no
`User-Agent`, outside the `RetryPolicy` and the OAuth2 `401`-challenge retry, and its response
was deserialized without a status check. Against an authenticated coordinator `execute`
therefore failed where `get_all` / `stream` succeeded on the same client, as a misleading
`Error::HttpError("error decoding response body")`, after the statement had already run.

That request is now gone rather than authenticated: the pagination loop has already fetched and
parsed the final page, and `QueryResult` carries the `error`, `update_type` and `update_count`
`execute` was reading off `TrinoRetryResult`. So `execute` also makes one HTTP request fewer,
and no longer returns `Error::InternalError("No next URI available for execution result")` when
the first response carries no `next_uri`.

`TrinoRetryResult` and `TrinoStats` are left `pub` and `#[deprecated]` rather than removed, so
nothing breaks; removal is noted for the next major.

Two wiremock tests: one asserting every request `execute` makes carries the auth and identity
headers (it fails on `main` with exactly the reported `HttpError(Decode)`, and `expect(1)` +
`server.verify()` pin that no page is fetched twice), one asserting a `401` on a page fetch
arrives as `Error::HttpNotOk`.